### PR TITLE
Allow `buildAndValidate` to cause failures

### DIFF
--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -29,7 +29,11 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
     /**
      Deleting a database failed.
      */
-    CDTObjectiveCloudantErrorDeleteDatabaseFailed
+    CDTObjectiveCloudantErrorDeleteDatabaseFailed,
+    /**
+     Validation of operation settings failed.
+     */
+    CDTObjectiveCloudantErrorValidationFailed
 };
 
 /**
@@ -72,13 +76,24 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
 
  Typically an operation would add to queryItems here.
  */
-- (void)buildAndValidate;
+- (BOOL)buildAndValidate;
 
 /**
  Override point for sub-classes. Dispatch an async HTTP request. Call `completeOperation` when
  complete.
  */
 - (void)dispatchAsyncHttpRequest;
+
+/**
+ CDTCouchOperation will call this method if it encounters an error. Usually this will
+ happen if `-buildAndValidate:` returns `NO`. Sub-classes must override this to call their
+ completion handler with the provided error.
+
+ This will never be called after `-dispatchAsyncHttpRequest`.
+
+ Overrides should NOT call `completeOperation`.
+ */
+- (void)callCompletionHandlerWithError:(NSError *)error;
 
 /// ---------------------------------
 /// @name Life-cycle management

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.m
@@ -21,9 +21,11 @@ NSString *const CDTObjectiveCloudantErrorDomain = @"CDTObjectiveCloudantErrorDom
 
 #pragma mark Sub-class overrides
 
-- (void)buildAndValidate { return; }
+- (BOOL)buildAndValidate { return YES; }
 
 - (void)dispatchAsyncHttpRequest { return; }
+
+- (void)callCompletionHandlerWithError:(NSError *)error { return; }
 
 #pragma mark Concurrent operation NSOperation functions
 
@@ -54,9 +56,23 @@ NSString *const CDTObjectiveCloudantErrorDomain = @"CDTObjectiveCloudantErrorDom
         return;
     }
 
+    // Validate settings before starting execution
+    if (![self buildAndValidate]) {
+        NSString *msg = [NSString stringWithFormat:@"Validation of operation failed."];
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : NSLocalizedString(msg, nil)};
+        NSError *error = [NSError errorWithDomain:CDTObjectiveCloudantErrorDomain
+                                             code:CDTObjectiveCloudantErrorValidationFailed
+                                         userInfo:userInfo];
+        [self callCompletionHandlerWithError:error];
+
+        [self willChangeValueForKey:@"isFinished"];
+        finished = YES;
+        [self didChangeValueForKey:@"isFinished"];
+        return;
+    }
+
     // If the operation is not canceled, begin executing the task.
     [self willChangeValueForKey:@"isExecuting"];
-    [self buildAndValidate];
     [self dispatchAsyncHttpRequest];
     executing = YES;
     [self didChangeValueForKey:@"isExecuting"];

--- a/ObjectiveCloudant/Operations/CDTCreateDatabaseOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCreateDatabaseOperation.m
@@ -23,7 +23,14 @@
 
 @implementation CDTCreateDatabaseOperation
 
-- (void)buildAndValidate { [super buildAndValidate]; }
+- (BOOL)buildAndValidate { return [super buildAndValidate]; }
+
+- (void)callCompletionHandlerWithError:(NSError *)error
+{
+    if (self && self.createDatabaseCompletionBlock) {
+        self.createDatabaseCompletionBlock(0, error);
+    }
+}
 
 #pragma mark Instance methods
 

--- a/ObjectiveCloudant/Operations/CDTDeleteDatabaseOperation.m
+++ b/ObjectiveCloudant/Operations/CDTDeleteDatabaseOperation.m
@@ -23,9 +23,16 @@
 
 @implementation CDTDeleteDatabaseOperation
 
-- (void)buildAndValidate { [super buildAndValidate]; }
+- (BOOL)buildAndValidate { return [super buildAndValidate]; }
 
 #pragma mark Instance methods
+
+- (void)callCompletionHandlerWithError:(NSError *)error
+{
+    if (self && self.deleteDatabaseCompletionBlock) {
+        self.deleteDatabaseCompletionBlock(error);
+    }
+}
 
 - (void)dispatchAsyncHttpRequest
 {

--- a/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
@@ -23,15 +23,29 @@
 
 @implementation CDTGetDocumentOperation
 
-- (void)buildAndValidate
+- (BOOL)buildAndValidate
 {
-    [super buildAndValidate];
+    if ([super buildAndValidate]) {
+        if (self.docId) {
+            self.queryItems = @[
+                [NSURLQueryItem queryItemWithName:@"revs" value:(self.revs ? @"true" : @"false")]
+            ];
 
-    self.queryItems =
-        @[ [NSURLQueryItem queryItemWithName:@"revs" value:(self.revs ? @"true" : @"false")] ];
+            return YES;
+        }
+    }
+
+    return NO;
 }
 
 #pragma mark Instance methods
+
+- (void)callCompletionHandlerWithError:(NSError *)error
+{
+    if (self && self.getDocumentCompletionBlock) {
+        self.getDocumentCompletionBlock(nil, error);
+    }
+}
 
 - (void)dispatchAsyncHttpRequest
 {

--- a/ObjectiveCloudant/Operations/CDTPutDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTPutDocumentOperation.m
@@ -23,24 +23,32 @@
 
 @implementation CDTPutDocumentOperation
 
-- (void)buildAndValidate
+- (BOOL)buildAndValidate
 {
-    [super buildAndValidate];
+    if ([super buildAndValidate]) {
+        if (self.docId && self.body && [NSJSONSerialization isValidJSONObject:self.body]) {
+            NSMutableArray *tmp = [NSMutableArray array];
 
-    NSAssert(self.docId, @"docId was nil");
-    NSAssert(self.body, @"body was nil");
-    NSAssert([NSJSONSerialization isValidJSONObject:self.body], @"body was invalid JSON");
+            if (self.revId) {
+                [tmp addObject:[NSURLQueryItem queryItemWithName:@"rev" value:self.revId]];
+            }
 
-    NSMutableArray *tmp = [NSMutableArray array];
+            self.queryItems = [NSArray arrayWithArray:tmp];
 
-    if (self.revId) {
-        [tmp addObject:[NSURLQueryItem queryItemWithName:@"rev" value:self.revId]];
+            return YES;
+        }
     }
-
-    self.queryItems = [NSArray arrayWithArray:tmp];
+    return NO;
 }
 
 #pragma mark Instance methods
+
+- (void)callCompletionHandlerWithError:(NSError *)error
+{
+    if (self && self.putDocumentCompletionBlock) {
+        self.putDocumentCompletionBlock(0, nil, nil, error);
+    }
+}
 
 - (void)dispatchAsyncHttpRequest
 {


### PR DESCRIPTION
## What

Allow the `buildAndValidate` method to return a flag indicating that the object has failed validation. The `start` method will then call the callback for the operation with the appropriate error object.
## How

Change the signature of `buildAndValidate` to return a `BOOL` to indicate if validation passed. If it did not then call the call back with the error flag set to true.
