### PR TITLE
Create CQ JSON Indexes

### DIFF
--- a/ObjectiveCloudant.xcodeproj/project.pbxproj
+++ b/ObjectiveCloudant.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		984AA65E1BB00B8C003D4DCA /* DeleteDocumentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 984AA65D1BB00B8C003D4DCA /* DeleteDocumentTests.m */; settings = {ASSET_TAGS = (); }; };
 		98629D671BB40EF900E7F5E8 /* CDTCouchOperation+internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 98629D651BB40EF900E7F5E8 /* CDTCouchOperation+internal.h */; settings = {ASSET_TAGS = (); }; };
 		98629D681BB40EF900E7F5E8 /* CDTCouchOperation+internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 98629D661BB40EF900E7F5E8 /* CDTCouchOperation+internal.m */; settings = {ASSET_TAGS = (); }; };
+		984AA6611BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 984AA65F1BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		984AA6621BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 984AA6601BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.m */; settings = {ASSET_TAGS = (); }; };
+		9896FE801BB57DAD00856BD7 /* CreateIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9896FE7F1BB57DAD00856BD7 /* CreateIndexTests.m */; settings = {ASSET_TAGS = (); }; };
 		AF09BD7CDDCA1320E802F047 /* Pods_ObjectiveCloudantTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D84D0A0BCF45916FACA3CDB5 /* Pods_ObjectiveCloudantTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
@@ -109,6 +112,9 @@
 		984AA65D1BB00B8C003D4DCA /* DeleteDocumentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DeleteDocumentTests.m; path = ObjectiveCloudantTests/DeleteDocumentTests.m; sourceTree = SOURCE_ROOT; };
 		98629D651BB40EF900E7F5E8 /* CDTCouchOperation+internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "CDTCouchOperation+internal.h"; path = "ObjectiveCloudant/Operations/CDTCouchOperation+internal.h"; sourceTree = SOURCE_ROOT; };
 		98629D661BB40EF900E7F5E8 /* CDTCouchOperation+internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "CDTCouchOperation+internal.m"; path = "ObjectiveCloudant/Operations/CDTCouchOperation+internal.m"; sourceTree = SOURCE_ROOT; };
+		984AA65F1BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTCreateQueryIndexOperation.h; sourceTree = "<group>"; };
+		984AA6601BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTCreateQueryIndexOperation.m; sourceTree = "<group>"; };
+		9896FE7F1BB57DAD00856BD7 /* CreateIndexTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CreateIndexTests.m; path = ObjectiveCloudantTests/CreateIndexTests.m; sourceTree = SOURCE_ROOT; };
 		D84D0A0BCF45916FACA3CDB5 /* Pods_ObjectiveCloudantTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ObjectiveCloudantTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -143,6 +149,8 @@
 				275B9CCC1BA9D3540023CB63 /* CDTPutDocumentOperation.m */,
 				984AA6591BAFF8C4003D4DCA /* CDTDeleteDocumentOperation.h */,
 				984AA65A1BAFF8C4003D4DCA /* CDTDeleteDocumentOperation.m */,
+				984AA65F1BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.h */,
+				984AA6601BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.m */,
 			);
 			name = "Operations - Database";
 			path = ObjectiveCloudant/Operations;
@@ -193,6 +201,7 @@
 				27F6B7261BA9C7A4000B523E /* CreateDatabaseTests.m */,
 				27F6B72C1BA9CA0F000B523E /* DeleteDatabaseTests.m */,
 				274CF6841B9055F6008BBD50 /* ObjectiveCloudantTests.m */,
+				9896FE7F1BB57DAD00856BD7 /* CreateIndexTests.m */,
 				275B9CCF1BA9D3770023CB63 /* PutDocumentTests.m */,
 				27F6B71D1BA9C243000B523E /* TestHelpers.h */,
 				27F6B71E1BA9C243000B523E /* TestHelpers.m */,
@@ -282,6 +291,7 @@
 				984AA65B1BAFF8C4003D4DCA /* CDTDeleteDocumentOperation.h in Headers */,
 				274CF67D1B9055B9008BBD50 /* CDTGetDocumentOperation.h in Headers */,
 				274CF6751B9055B9008BBD50 /* CDTDatabase.h in Headers */,
+				984AA6611BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.h in Headers */,
 				27F6B72A1BA9C98C000B523E /* CDTDeleteDatabaseOperation.h in Headers */,
 				27F6B7241BA9C322000B523E /* CDTCreateDatabaseOperation.h in Headers */,
 			);
@@ -437,6 +447,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				275B9CCE1BA9D3540023CB63 /* CDTPutDocumentOperation.m in Sources */,
+				984AA6621BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.m in Sources */,
 				984AA63B1BAAFA08003D4DCA /* CDTInterceptableSession.m in Sources */,
 				274CF67C1B9055B9008BBD50 /* CDTCouchOperation.m in Sources */,
 				984AA63E1BAAFA08003D4DCA /* CDTURLSessionTask.m in Sources */,
@@ -464,6 +475,7 @@
 				984AA65E1BB00B8C003D4DCA /* DeleteDocumentTests.m in Sources */,
 				984AA6571BAC5CA0003D4DCA /* CDTURLSessionTests.m in Sources */,
 				275B9CD01BA9D3770023CB63 /* PutDocumentTests.m in Sources */,
+				9896FE801BB57DAD00856BD7 /* CreateIndexTests.m in Sources */,
 				984AA6561BAC5CA0003D4DCA /* CDTURLSessionTaskTests.m in Sources */,
 				27F6B7211BA9C266000B523E /* TestHelpers.m in Sources */,
 			);

--- a/ObjectiveCloudant/ObjectiveCloudant.h
+++ b/ObjectiveCloudant/ObjectiveCloudant.h
@@ -38,3 +38,4 @@ FOUNDATION_EXPORT const unsigned char ObjectiveCloudantVersionString[];
 #import <ObjectiveCloudant/CDTInterceptableSession.h>
 #import <ObjectiveCloudant/CDTSessionCookieInterceptor.h>
 #import <ObjectiveCloudant/CDTDeleteDocumentOperation.h>
+#import <ObjectiveCloudant/CDTCreateQueryIndexOperation.h>

--- a/ObjectiveCloudant/Operations/CDTCreateQueryIndexOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCreateQueryIndexOperation.h
@@ -1,0 +1,60 @@
+//
+//  CDTCreateQueryIndexOperation.h
+//  ObjectiveCloudant
+//
+//  Created by Rhys Short on 22/09/2015.
+//  Copyright (c) 2015 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <ObjectiveCloudant/ObjectiveCloudant.h>
+
+/**
+ * The types of index that can be used with
+ * Cloudant Query.
+ */
+typedef NS_ENUM(NSUInteger, CDTQIndexType) { CDTQIndexTypeJson };
+
+@interface CDTCreateQueryIndexOperation : CDTCouchDatabaseOperation
+
+/**
+ * The name of the index.
+ * Optional: CouchDb will automatically generate an index name
+ * if its not set.
+ **/
+@property (nullable, nonatomic, strong) NSString* indexName;
+
+/**
+ *  The fields to be included in the index.
+ *  Required: Needs to be set with a non zero length array.
+ **/
+@property (nullable, nonatomic, strong) NSArray<NSObject*>* fields;
+
+/**
+ * The index type to use, deafults to json.
+ **/
+@property (nonatomic) CDTQIndexType indexType;
+
+/**
+ * The name of the design doc this index should be included with
+ * Optional: CouchDB will automatically generate a deisgn doc
+ * for this index.
+ **/
+@property (nullable, nonatomic, strong) NSString* designDocName;
+
+/**
+ * Completion block to run when the operation completes
+ *
+ * status - the status code from the HTTP request, 0 if HTTP request hasn't been made
+ * operationError - and error with the operation
+ **/
+@property (nullable, nonatomic, strong) void (^createIndexCompletionBlock)
+    (NSInteger status, NSError* _Nullable operationError);
+
+@end

--- a/ObjectiveCloudant/Operations/CDTCreateQueryIndexOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCreateQueryIndexOperation.m
@@ -1,0 +1,158 @@
+//
+//  CDTCreateQueryIndexOperation.m
+//  ObjectiveCloudant
+//
+//  Created by Rhys Short on 22/09/2015.
+//  Copyright (c) 2015 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTCreateQueryIndexOperation.h"
+
+// Testing this class will need to mock the entire query back end,
+// XCTest doesn't provide a way to skip tests based on conditions
+@interface CDTCreateQueryIndexOperation ()
+
+@property (nullable, nonatomic, strong) NSData *jsonBody;
+@property (nullable, nonatomic, strong) CDTURLSessionTask *task;
+@property NSURLRequest *request;
+
+@end
+
+@implementation CDTCreateQueryIndexOperation
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _indexType = CDTQIndexTypeJson;
+    }
+    return self;
+}
+
+- (BOOL)buildAndValidate
+{
+    if (![super buildAndValidate]) {
+        return NO;
+    }
+
+    // fields is the only required parameter
+    if ((!self.fields) || self.fields.count == 0) {
+        return NO;
+    } else {
+        // check the fields are either string or 2 element dict of strings
+        for (NSObject *item in self.fields) {
+            if ([item isKindOfClass:[NSString class]]) {
+                continue;
+            } else if ([item isKindOfClass:[NSDictionary class]]) {
+                // must be only one key, both strings.
+                NSDictionary *sort = (NSDictionary *)item;
+                if (sort.count != 1) {
+                    return NO;
+                }
+
+                if (![sort.allKeys[0] isKindOfClass:[NSString class]]) {
+                    return NO;
+                }
+
+                NSString *key = sort.allKeys[0];
+
+                if (![sort[key] isKindOfClass:[NSString class]]) {
+                    return NO;
+                } else if (![sort[key] isEqualToString:@"asc"] &&
+                           ![sort[key] isEqualToString:@"desc"]) {
+                    return NO;
+                }
+
+            } else {
+                return NO;
+            }
+        }
+    }
+
+    NSMutableDictionary *body = [NSMutableDictionary dictionary];
+    body[@"index"] = @{ @"fields" : self.fields };
+    body[@"type"] = @"json";  // only type supported for now.
+    if (self.indexName) {
+        body[@"name"] = self.indexName;
+    }
+    if (self.designDocName) {
+        body[@"ddoc"] = self.designDocName;
+    }
+
+    NSError *error = nil;
+
+    self.jsonBody = [NSJSONSerialization dataWithJSONObject:body options:0 error:&error];
+
+    return (self.jsonBody != nil);
+}
+
+- (void)callCompletionHandlerWithError:(NSError *)error
+{
+    if (self.createIndexCompletionBlock) {
+        self.createIndexCompletionBlock(kCDTNoHTTPStatus, error);
+    }
+}
+
+- (void)dispatchAsyncHttpRequest
+{
+    NSString *path = [NSString stringWithFormat:@"/%@/_index", self.databaseName];
+
+    NSURLComponents *components =
+        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
+    components.path = path;
+
+    NSLog(@"%@", [[components URL] absoluteString]);
+
+    NSMutableURLRequest *request =
+        [NSMutableURLRequest requestWithURL:components.URL
+                                cachePolicy:NSURLRequestUseProtocolCachePolicy
+                            timeoutInterval:10.0];
+    request.HTTPMethod = @"POST";
+    request.HTTPBody = self.jsonBody;
+
+    self.request = request;
+
+    __weak CDTCreateQueryIndexOperation *weakSelf = self;
+    self.task = [self.session
+        dataTaskWithRequest:request
+          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            CDTCreateQueryIndexOperation *strongSelf = weakSelf;
+
+            // mark operation as complete and return if strongSelf is `nil`, OR
+            // completionBlock is `nil` OR  the operation has been cancelled.
+            if (!strongSelf || !strongSelf.createIndexCompletionBlock || [self isCancelled]) {
+                [strongSelf completeOperation];
+                return;
+            }
+
+            NSInteger statusCode = ((NSHTTPURLResponse *)response).statusCode;
+            if (!error && data && statusCode / 100 == 2) {
+                strongSelf.createIndexCompletionBlock(((NSHTTPURLResponse *)response).statusCode,
+                                                      nil);
+            } else if (error) {
+                strongSelf.createIndexCompletionBlock(kCDTNoHTTPStatus, error);
+            } else {
+                NSString *json = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+                NSString *msg = [NSString
+                    stringWithFormat:@"Index creation failed with %ld %@.", statusCode, json];
+                NSDictionary *userInfo = @{NSLocalizedDescriptionKey : NSLocalizedString(msg, nil)};
+                error = [NSError errorWithDomain:CDTObjectiveCloudantErrorDomain
+                                            code:CDTObjectiveCloudantErrorCreateDatabaseFailed
+                                        userInfo:userInfo];
+                strongSelf.createIndexCompletionBlock(statusCode, error);
+            }
+
+            [strongSelf completeOperation];
+
+          }];
+    [self.task resume];
+}
+
+@end

--- a/ObjectiveCloudant/Operations/CDTDeleteDatabaseOperation.m
+++ b/ObjectiveCloudant/Operations/CDTDeleteDatabaseOperation.m
@@ -57,7 +57,7 @@
             CDTDeleteDatabaseOperation *self = weakSelf;
 
             if ([self isCancelled]) {
-                [strongSelf completeOperation];
+                [self completeOperation];
                 return;
             }
 

--- a/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
@@ -71,7 +71,7 @@
                           CDTGetDocumentOperation *self = weakSelf;
 
                           if ([self isCancelled]) {
-                              [strongSelf completeOperation];
+                              [self completeOperation];
                               return;
                           }
 

--- a/ObjectiveCloudant/Operations/CDTPutDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTPutDocumentOperation.m
@@ -74,7 +74,7 @@
             CDTPutDocumentOperation *self = weakSelf;
 
             if ([self isCancelled]) {
-                [strongSelf completeOperation];
+                [self completeOperation];
                 return;
             }
 

--- a/ObjectiveCloudantTests/CreateIndexTests.m
+++ b/ObjectiveCloudantTests/CreateIndexTests.m
@@ -1,0 +1,339 @@
+//
+//  CreateIndexTests.m
+//  ObjectiveCloudant
+//
+//  Created by Rhys Short on 25/09/2015.
+//  Copyright (c) 2015 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <XCTest/XCTest.h>
+#import <OHHTTPStubs/OHHTTPStubs.h>
+#import <ObjectiveCloudant/ObjectiveCloudant.h>
+#import "TestHelpers.h"
+
+@interface CreateIndexTests : XCTestCase
+@property (nonatomic, strong) NSString *url;
+@property (nonatomic, strong) NSString *dbName;
+@property (nonatomic, strong) NSString *username;
+@property (nonatomic, strong) NSString *password;
+@property (nonatomic, strong) CDTDatabase *database;
+
+@end
+
+@implementation CreateIndexTests
+
+- (void)setUp
+{
+    [super setUp];
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *_Nonnull request) {
+      return [request.URL.path containsString:@"_index"];
+    }
+        withStubResponse:^OHHTTPStubsResponse *_Nonnull(NSURLRequest *_Nonnull request) {
+          return [OHHTTPStubsResponse responseWithJSONObject:@{
+              @"ok" : @(YES)
+          }
+                                                  statusCode:200
+                                                     headers:@{}];
+        }];
+
+    self.url = @"http://localhost:5984";
+    self.username = nil;
+    self.password = nil;
+
+    // These tests require their own database as they modify content; create one
+
+    self.dbName = [NSString stringWithFormat:@"%@-test-database-%@", REMOTE_DB_PREFIX,
+                                             [TestHelpers generateRandomString:5]];
+
+    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
+                                   username:self.username
+                                   password:self.password];
+    self.database = client[self.dbName];
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    [super tearDown];
+    [OHHTTPStubs removeAllStubs];
+}
+
+- (void)testIndexCreation
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @"foo", @"bar" ];
+    index.indexName = @"foobarIndex";
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+      XCTAssertEqual(200, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationSortSyntaxAsc
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"foo" : @"asc" } ];
+    index.indexName = @"foobarIndex";
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+      XCTAssertEqual(200, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationSortSyntaxdesc
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"foo" : @"desc" } ];
+    index.indexName = @"foobarIndex";
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+      XCTAssertEqual(200, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationSortSyntaxDescAsec
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"foo" : @"desc" }, @{ @"bar" : @"asc" } ];
+    index.indexName = @"foobarIndex";
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+      XCTAssertEqual(200, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationSortSyntaxMixed
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"foo" : @"asc" }, @{ @"bar" : @"desc" }, @"hello" ];
+    index.indexName = @"foobarIndex";
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+      XCTAssertEqual(200, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithoutFields
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.indexName = @"foobarIndex";
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+      XCTAssertEqual(0, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationValidationPassesWithoutOptionalValuesSet
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @"foo", @"bar" ];
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+      XCTAssertEqual(200, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithEmptyArray
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[];
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+      XCTAssertEqual(0, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithEmptyDictFields
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{} ];
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+      XCTAssertEqual(0, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithDictKeyInt
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @(100) : @"World" } ];
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+      XCTAssertEqual(0, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithDictValueNotExpected
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"Hello" : @"World" } ];
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+      XCTAssertEqual(0, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreation5xxError
+{
+    [OHHTTPStubs removeAllStubs];
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *_Nonnull request) {
+      return [request.URL.path containsString:@"_index"];
+    }
+        withStubResponse:^OHHTTPStubsResponse *_Nonnull(NSURLRequest *_Nonnull request) {
+          return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:500 headers:@{}];
+        }];
+
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @"foo", @"bar" ];
+    index.indexName = @"foobarIndex";
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+      XCTAssertEqual(500, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreation4xxError
+{
+    [OHHTTPStubs removeAllStubs];
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *_Nonnull request) {
+      return [request.URL.path containsString:@"_index"];
+    }
+        withStubResponse:^OHHTTPStubsResponse *_Nonnull(NSURLRequest *_Nonnull request) {
+          return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+        }];
+
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @"foo", @"bar" ];
+    index.indexName = @"foobarIndex";
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSInteger status, NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+      XCTAssertEqual(400, status);
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+@end


### PR DESCRIPTION
## What

Add support for creating JSON Cloudant Query Indexes.
## How

Create `CDTQCreateIndexOperation` class, which handles the request to create the index.
## Testing

`CreateIndexTests` tests the operation using HTTP stubs to ensure the tests will pass when running with a CouchDB instance that doesn't have support for Mango.
## Reviewers

reviewer @tomblench 
reviewer @mikerhodes 
