### PR TITLE
Rename CouchDB to CDTCouchDBClient

### DIFF
--- a/ObjectiveCloudant.xcodeproj/project.pbxproj
+++ b/ObjectiveCloudant.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		274CF6731B9055B9008BBD50 /* CouchDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 274CF6661B9055B9008BBD50 /* CouchDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		274CF6741B9055B9008BBD50 /* CouchDB.m in Sources */ = {isa = PBXBuildFile; fileRef = 274CF6671B9055B9008BBD50 /* CouchDB.m */; };
+		274CF6731B9055B9008BBD50 /* CDTCouchDBClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 274CF6661B9055B9008BBD50 /* CDTCouchDBClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		274CF6741B9055B9008BBD50 /* CDTCouchDBClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 274CF6671B9055B9008BBD50 /* CDTCouchDBClient.m */; };
 		274CF6751B9055B9008BBD50 /* CDTDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 274CF6681B9055B9008BBD50 /* CDTDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		274CF6761B9055B9008BBD50 /* CDTDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 274CF6691B9055B9008BBD50 /* CDTDatabase.m */; };
 		274CF6771B9055B9008BBD50 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 274CF66A1B9055B9008BBD50 /* Info.plist */; };
@@ -67,8 +67,8 @@
 
 /* Begin PBXFileReference section */
 		2475D3C3038B0291D094C46B /* Pods-ObjectiveCloudantTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectiveCloudantTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectiveCloudantTests/Pods-ObjectiveCloudantTests.release.xcconfig"; sourceTree = "<group>"; };
-		274CF6661B9055B9008BBD50 /* CouchDB.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CouchDB.h; path = ObjectiveCloudant/CouchDB.h; sourceTree = SOURCE_ROOT; };
-		274CF6671B9055B9008BBD50 /* CouchDB.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CouchDB.m; path = ObjectiveCloudant/CouchDB.m; sourceTree = SOURCE_ROOT; };
+		274CF6661B9055B9008BBD50 /* CDTCouchDBClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTCouchDBClient.h; path = ObjectiveCloudant/CDTCouchDBClient.h; sourceTree = SOURCE_ROOT; };
+		274CF6671B9055B9008BBD50 /* CDTCouchDBClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTCouchDBClient.m; path = ObjectiveCloudant/CDTCouchDBClient.m; sourceTree = SOURCE_ROOT; };
 		274CF6681B9055B9008BBD50 /* CDTDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTDatabase.h; path = ObjectiveCloudant/CDTDatabase.h; sourceTree = SOURCE_ROOT; };
 		274CF6691B9055B9008BBD50 /* CDTDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTDatabase.m; path = ObjectiveCloudant/CDTDatabase.m; sourceTree = SOURCE_ROOT; };
 		274CF66A1B9055B9008BBD50 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ObjectiveCloudant/Info.plist; sourceTree = SOURCE_ROOT; };
@@ -182,8 +182,8 @@
 				984AA6131BAAF99E003D4DCA /* HTTP */,
 				27F6B72E1BA9CFED000B523E /* Operations - Instance */,
 				274CF66C1B9055B9008BBD50 /* Operations - Database */,
-				274CF6661B9055B9008BBD50 /* CouchDB.h */,
-				274CF6671B9055B9008BBD50 /* CouchDB.m */,
+				274CF6661B9055B9008BBD50 /* CDTCouchDBClient.h */,
+				274CF6671B9055B9008BBD50 /* CDTCouchDBClient.m */,
 				274CF6681B9055B9008BBD50 /* CDTDatabase.h */,
 				274CF6691B9055B9008BBD50 /* CDTDatabase.m */,
 				274CF66A1B9055B9008BBD50 /* Info.plist */,
@@ -278,8 +278,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				274CF6791B9055B9008BBD50 /* CDTCouchDatabaseOperation.h in Headers */,
-				274CF6731B9055B9008BBD50 /* CouchDB.h in Headers */,
 				98629D671BB40EF900E7F5E8 /* CDTCouchOperation+internal.h in Headers */,
+				274CF6731B9055B9008BBD50 /* CDTCouchDBClient.h in Headers */,
 				274CF67B1B9055B9008BBD50 /* CDTCouchOperation.h in Headers */,
 				274CF6781B9055B9008BBD50 /* ObjectiveCloudant.h in Headers */,
 				275B9CCD1BA9D3540023CB63 /* CDTPutDocumentOperation.h in Headers */,
@@ -459,7 +459,7 @@
 				274CF6761B9055B9008BBD50 /* CDTDatabase.m in Sources */,
 				984AA65C1BAFF8C4003D4DCA /* CDTDeleteDocumentOperation.m in Sources */,
 				98629D681BB40EF900E7F5E8 /* CDTCouchOperation+internal.m in Sources */,
-				274CF6741B9055B9008BBD50 /* CouchDB.m in Sources */,
+				274CF6741B9055B9008BBD50 /* CDTCouchDBClient.m in Sources */,
 				274CF67A1B9055B9008BBD50 /* CDTCouchDatabaseOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ObjectiveCloudant/CDTCouchDBClient.h
+++ b/ObjectiveCloudant/CDTCouchDBClient.h
@@ -1,5 +1,5 @@
 //
-//  Cloudant.h
+//  CDTCouchDBClient.h
 //  ObjectiveCouch
 //
 //  Created by Michael Rhodes on 15/08/2015.
@@ -19,7 +19,7 @@
 @class CDTDatabase;
 @class CDTCouchOperation;
 
-@interface CouchDB : NSObject
+@interface CDTCouchDBClient : NSObject
 
 /**
  Create a client for a given CouchDB instance using username and password.
@@ -28,9 +28,9 @@
  @param username Username to use. May be `nil`.
  @param password Password to use. May be `nil`.
  */
-+ (nullable CouchDB *)clientForURL:(nonnull NSURL *)url
-                          username:(nullable NSString *)username
-                          password:(nullable NSString *)password;
++ (nullable CDTCouchDBClient *)clientForURL:(nonnull NSURL *)url
+                                   username:(nullable NSString *)username
+                                   password:(nullable NSString *)password;
 
 /**
  Retrieve a database object for this client.

--- a/ObjectiveCloudant/CDTCouchDBClient.m
+++ b/ObjectiveCloudant/CDTCouchDBClient.m
@@ -1,5 +1,5 @@
 //
-//  Cloudant.m
+//  CDTCouchDBClient.m
 //  ObjectiveCouch
 //
 //  Created by Michael Rhodes on 15/08/2015.
@@ -14,14 +14,14 @@
 //  and limitations under the License.
 //
 
-#import "CouchDB.h"
+#import "CDTCouchDBClient.h"
 #import "CDTCouchOperation.h"
 #import "CDTInterceptableSession.h"
 #import "CDTSessionCookieInterceptor.h"
 
 #import "CDTDatabase.h"
 
-@interface CouchDB ()
+@interface CDTCouchDBClient ()
 
 @property (nullable, nonatomic, strong) NSString *username;
 @property (nullable, nonatomic, strong) NSString *password;
@@ -36,13 +36,13 @@
 
 @end
 
-@implementation CouchDB
+@implementation CDTCouchDBClient
 
-+ (nullable CouchDB *)clientForURL:(nonnull NSURL *)url
-                          username:(nullable NSString *)username
-                          password:(nullable NSString *)password
++ (nullable CDTCouchDBClient *)clientForURL:(nonnull NSURL *)url
+                                   username:(nullable NSString *)username
+                                   password:(nullable NSString *)password
 {
-    return [[CouchDB alloc] initForURL:url username:username password:password];
+    return [[CDTCouchDBClient alloc] initForURL:url username:username password:password];
 }
 
 - (nullable instancetype)initForURL:(nullable NSURL *)url

--- a/ObjectiveCloudant/CDTDatabase.h
+++ b/ObjectiveCloudant/CDTDatabase.h
@@ -1,5 +1,5 @@
 //
-//  Database.h
+//  CDTDatabase.h
 //  ObjectiveCouch
 //
 //  Created by Michael Rhodes on 15/08/2015.
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class CouchDB;
+@class CDTCouchDBClient;
 @class CDTGetDocumentOperation;
 @class CDTCouchDatabaseOperation;
 
@@ -25,7 +25,7 @@
 /**
  Initialises a new database object with a CouchDB client and database name.
  */
-- (nullable instancetype)initWithClient:(nonnull CouchDB *)client
+- (nullable instancetype)initWithClient:(nonnull CDTCouchDBClient *)client
                            databaseName:(nonnull NSString *)name;
 
 /**

--- a/ObjectiveCloudant/CDTDatabase.m
+++ b/ObjectiveCloudant/CDTDatabase.m
@@ -1,5 +1,5 @@
 //
-//  Database.m
+//  CDTDatabase.m
 //  ObjectiveCouch
 //
 //  Created by Michael Rhodes on 15/08/2015.
@@ -16,21 +16,21 @@
 
 #import "CDTDatabase.h"
 
-#import "CouchDB.h"
+#import "CDTCouchDBClient.h"
 #import "CDTGetDocumentOperation.h"
 #import "CDTDeleteDocumentOperation.h"
 #import "CDTPutDocumentOperation.h"
 
 @interface CDTDatabase ()
 
-@property (nonnull, nonatomic, strong) CouchDB *client;
+@property (nonnull, nonatomic, strong) CDTCouchDBClient *client;
 @property (nonnull, nonatomic, strong) NSString *databaseName;
 
 @end
 
 @implementation CDTDatabase
 
-- (nullable instancetype)initWithClient:(nonnull CouchDB *)client
+- (nullable instancetype)initWithClient:(nonnull CDTCouchDBClient *)client
                            databaseName:(nonnull NSString *)name
 {
     self = [super init];

--- a/ObjectiveCloudant/HTTP/CDTHTTPInterceptor.h
+++ b/ObjectiveCloudant/HTTP/CDTHTTPInterceptor.h
@@ -1,5 +1,5 @@
 //
-//  CDTURLSessionInterceptor.h
+//  CDTHTTPInterceptor.h
 //
 //
 //  Created by Rhys Short on 24/08/2015.

--- a/ObjectiveCloudant/HTTP/CDTHTTPInterceptorContext.h
+++ b/ObjectiveCloudant/HTTP/CDTHTTPInterceptorContext.h
@@ -1,5 +1,5 @@
 //
-//  CDTURLSessionFilterContext.h
+//  CDTHTTPInterceptorContext.h
 //
 //
 //  Created by Rhys Short on 17/08/2015.

--- a/ObjectiveCloudant/ObjectiveCloudant.h
+++ b/ObjectiveCloudant/ObjectiveCloudant.h
@@ -25,7 +25,7 @@ FOUNDATION_EXPORT const unsigned char ObjectiveCloudantVersionString[];
 // In this header, you should import all the public headers of your framework
 // using statements like #import <ObjectiveCloudant/PublicHeader.h>
 
-#import <ObjectiveCloudant/CouchDB.h>
+#import <ObjectiveCloudant/CDTCouchDBClient.h>
 #import <ObjectiveCloudant/CDTDatabase.h>
 #import <ObjectiveCloudant/CDTCouchOperation.h>
 #import <ObjectiveCloudant/CDTCouchDatabaseOperation.h>

--- a/ObjectiveCloudantTests/CreateDatabaseTests.m
+++ b/ObjectiveCloudantTests/CreateDatabaseTests.m
@@ -50,9 +50,9 @@
     // Put teardown code here. This method is called after the invocation of each test method in the
     // class.
 
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTDeleteDatabaseOperation *delete = [[CDTDeleteDatabaseOperation alloc] init];
     delete.databaseName = self.dbName;
@@ -64,9 +64,9 @@
 
 - (void)testCreateUsingPut
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     __block NSInteger statusCode;
 

--- a/ObjectiveCloudantTests/DeleteDatabaseTests.m
+++ b/ObjectiveCloudantTests/DeleteDatabaseTests.m
@@ -54,9 +54,9 @@
 
 - (void)testDeleteDatabase
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTCreateDatabaseOperation *create = [[CDTCreateDatabaseOperation alloc] init];
     create.databaseName = self.dbName;

--- a/ObjectiveCloudantTests/DeleteDocumentTests.m
+++ b/ObjectiveCloudantTests/DeleteDocumentTests.m
@@ -16,7 +16,7 @@
 @property NSString *username;
 @property NSString *password;
 @property NSString *dbName;
-@property CouchDB *client;
+@property CDTCouchDBClient *client;
 @property CDTDatabase *db;
 
 @end
@@ -38,9 +38,9 @@
     self.dbName = [NSString stringWithFormat:@"%@-test-database-%@", REMOTE_DB_PREFIX,
                                              [TestHelpers generateRandomString:5]];
 
-    self.client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                               username:self.username
-                               password:self.password];
+    self.client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                        username:self.username
+                                        password:self.password];
 
     CDTCreateDatabaseOperation *createDB = [[CDTCreateDatabaseOperation alloc] init];
     createDB.databaseName = self.dbName;
@@ -52,9 +52,9 @@
 
 - (void)tearDown
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTDeleteDatabaseOperation *delete = [[CDTDeleteDatabaseOperation alloc] init];
     delete.databaseName = self.dbName;

--- a/ObjectiveCloudantTests/ObjectiveCloudantTests.m
+++ b/ObjectiveCloudantTests/ObjectiveCloudantTests.m
@@ -47,9 +47,9 @@
 
 - (void)testCreateCloudantClient
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     NSString *expected = [NSString stringWithFormat:@"[url: %@]", self.url];
     XCTAssertEqualObjects(expected, [client description]);
@@ -57,9 +57,9 @@
 
 - (void)testGetDatabase
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTDatabase *database = client[@"objectivecouch-test"];
 
@@ -70,9 +70,9 @@
 
 - (void)testGetDocument
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTDatabase *database = client[@"objectivecouch-test"];
 
@@ -87,9 +87,9 @@
 
 - (void)testGetDocumentWithEmptyOptions
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTDatabase *database = client[@"objectivecouch-test"];
 
@@ -111,9 +111,9 @@
 
 - (void)testGetDocumentWithIncludeRevs
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTDatabase *database = client[@"objectivecouch-test"];
 

--- a/ObjectiveCloudantTests/PutDocumentTests.m
+++ b/ObjectiveCloudantTests/PutDocumentTests.m
@@ -45,9 +45,9 @@
     self.dbName = [NSString stringWithFormat:@"%@-test-database-%@", REMOTE_DB_PREFIX,
                                              [TestHelpers generateRandomString:5]];
 
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTCreateDatabaseOperation *create = [[CDTCreateDatabaseOperation alloc] init];
     create.databaseName = self.dbName;
@@ -60,9 +60,9 @@
     // Put teardown code here. This method is called after the invocation of each test method in the
     // class.
 
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     CDTDeleteDatabaseOperation *delete = [[CDTDeleteDatabaseOperation alloc] init];
     delete.databaseName = self.dbName;
@@ -74,9 +74,9 @@
 
 - (void)testPutDocumentCreate
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     NSString *docId = @"doc-testPutDocument";
 
@@ -104,9 +104,9 @@
 
 - (void)testPutDocumentUpdate
 {
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
 
     NSString *docId = @"doc-testPutDocument";
 


### PR DESCRIPTION
## What

Rename CouchDB to CDTCouchDBClient
## Why

To ensure class names do not clash all classes need a three letter prefix by convention. CDT is the prefix used by cloudant for our classes.
