### PR TITLE
Support getting a document at a specified rev

### DIFF
--- a/ObjectiveCloudant/CDTDatabase.h
+++ b/ObjectiveCloudant/CDTDatabase.h
@@ -51,6 +51,12 @@
         completionHandler:(void (^_Nonnull)(NSDictionary *_Nullable document,
                                             NSError *_Nullable error))completionHandler;
 
+- (void)getDocumentWithId:(nonnull NSString *)documentId
+               revisionId:(nonnull NSString *)revId
+        completionHandler:
+            (void (^_Nonnull)(NSDictionary<NSString *, NSObject *> *_Nullable document,
+                              NSError *_Nullable operationError))completionHandler;
+
 /**
  Convenience method of deleting documents from the database
 

--- a/ObjectiveCloudant/CDTDatabase.m
+++ b/ObjectiveCloudant/CDTDatabase.m
@@ -84,6 +84,18 @@
     [self addOperation:op];
 }
 
+- (void)getDocumentWithId:(NSString *)documentId
+               revisionId:(NSString *)revId
+        completionHandler:(void (^)(NSDictionary<NSString *, NSObject *> *_Nullable,
+                                    NSError *_Nullable))completionHandler
+{
+    CDTGetDocumentOperation *op = [[CDTGetDocumentOperation alloc] init];
+    op.docId = documentId;
+    op.revId = revId;
+    op.getDocumentCompletionBlock = completionHandler;
+    [self addOperation:op];
+}
+
 - (void)deleteDocumentWithId:(NSString *)documentId
                   revisionId:(NSString *)revId
          completetionHandler:(void (^)(NSInteger statusCode, NSError *_Nullable))completionHandler

--- a/ObjectiveCloudant/Operations/CDTCreateDatabaseOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCreateDatabaseOperation.m
@@ -18,8 +18,7 @@
 
 @implementation CDTCreateDatabaseOperation
 
-- (BOOL)buildAndValidate { return [super buildAndValidate]; }
-
+- (BOOL)buildAndValidate { return [super buildAndValidate] && self.databaseName; }
 - (void)callCompletionHandlerWithError:(NSError *)error
 {
     if (self && self.createDatabaseCompletionBlock) {

--- a/ObjectiveCloudant/Operations/CDTGetDocumentOperation.h
+++ b/ObjectiveCloudant/Operations/CDTGetDocumentOperation.h
@@ -22,6 +22,13 @@
 @property (nonatomic) bool revs;
 
 /**
+ *  The revision at which you want the document.
+ *  Optional: If ommited CouchDB will return the
+ *  document it determines is the current winning revision
+ */
+@property (nullable, nonatomic, strong) NSString *revId;
+
+/**
  The document that this operation will access or modify.
 
  Must be set before a call can be successfully made.

--- a/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
@@ -23,10 +23,14 @@
 {
     if ([super buildAndValidate]) {
         if (self.docId) {
-            self.queryItems = @[
-                [NSURLQueryItem queryItemWithName:@"revs" value:(self.revs ? @"true" : @"false")]
-            ];
-
+            NSMutableArray *queryItems = [NSMutableArray array];
+            [queryItems
+                addObject:[NSURLQueryItem queryItemWithName:@"revs"
+                                                      value:(self.revs ? @"true" : @"false")]];
+            if (self.revId) {
+                [queryItems addObject:[NSURLQueryItem queryItemWithName:@"rev" value:self.revId]];
+            }
+            self.queryItems = [queryItems copy];
             return YES;
         }
     }

--- a/ObjectiveCloudant/Operations/CDTPutDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTPutDocumentOperation.m
@@ -98,7 +98,7 @@
                     NSString *json =
                         [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
                     NSString *msg =
-                        [NSString stringWithFormat:@"Database creation failed with %ld %@.",
+                        [NSString stringWithFormat:@"Document operation failed with %ld %@.",
                                                    statusCode, json];
                     NSDictionary *userInfo =
                         @{NSLocalizedDescriptionKey : NSLocalizedString(msg, nil)};

--- a/ObjectiveCloudantTests/CreateIndexTests.m
+++ b/ObjectiveCloudantTests/CreateIndexTests.m
@@ -52,9 +52,9 @@
     self.dbName = [NSString stringWithFormat:@"%@-test-database-%@", REMOTE_DB_PREFIX,
                                              [TestHelpers generateRandomString:5]];
 
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
     self.database = client[self.dbName];
 }
 

--- a/ObjectiveCloudantTests/DeleteIndexTests.m
+++ b/ObjectiveCloudantTests/DeleteIndexTests.m
@@ -42,9 +42,9 @@
     self.dbName = [NSString stringWithFormat:@"%@-test-database-%@", REMOTE_DB_PREFIX,
                                              [TestHelpers generateRandomString:5]];
 
-    CouchDB *client = [CouchDB clientForURL:[NSURL URLWithString:self.url]
-                                   username:self.username
-                                   password:self.password];
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
     self.database = client[self.dbName];
 }
 
@@ -81,7 +81,7 @@
     XCTestExpectation *deleteIndex = [self expectationWithDescription:@"delete index"];
     CDTDeleteQueryIndexOperation *op = [[CDTDeleteQueryIndexOperation alloc] init];
     op.desginDocName = @"foo";
-    op.indexType = CDTQIndexTypeJson;
+    op.indexType = CDTQueryIndexTypeJson;
     op.deleteIndexCompletionBlock = ^(NSInteger statusCode, NSError *error) {
       [deleteIndex fulfill];
       XCTAssertEqual(kCDTNoHTTPStatus, statusCode);
@@ -110,7 +110,7 @@
     CDTDeleteQueryIndexOperation *op = [[CDTDeleteQueryIndexOperation alloc] init];
     op.desginDocName = @"foo";
     op.indexName = @"bar";
-    op.indexType = CDTQIndexTypeJson;
+    op.indexType = CDTQueryIndexTypeJson;
     op.deleteIndexCompletionBlock = ^(NSInteger statusCode, NSError *error) {
       [deleteIndex fulfill];
       XCTAssertEqual(4, statusCode / 100);
@@ -139,7 +139,7 @@
     CDTDeleteQueryIndexOperation *op = [[CDTDeleteQueryIndexOperation alloc] init];
     op.desginDocName = @"foo";
     op.indexName = @"bar";
-    op.indexType = CDTQIndexTypeJson;
+    op.indexType = CDTQueryIndexTypeJson;
     op.deleteIndexCompletionBlock = ^(NSInteger statusCode, NSError *error) {
       [deleteIndex fulfill];
       XCTAssertEqual(5, statusCode / 100);
@@ -177,7 +177,7 @@
     CDTDeleteQueryIndexOperation *op = [[CDTDeleteQueryIndexOperation alloc] init];
     op.desginDocName = @"foo";
     op.indexName = @"bar";
-    op.indexType = CDTQIndexTypeJson;
+    op.indexType = CDTQueryIndexTypeJson;
     op.deleteIndexCompletionBlock = ^(NSInteger statusCode, NSError *error) {
       [deleteIndex fulfill];
       XCTAssertEqual(200, statusCode);


### PR DESCRIPTION
## What

Support getting a document at a specified rev, avoiding the user to use the queryItems array.
## How

Add a property to CDTGetDocumentOperation that asks for the rev option
## Testing

See ObjectiveCloudant tests for an end to end test.
