### PR TITLE
51237 create query text index

### DIFF
--- a/ObjectiveCloudant/ObjectiveCloudant.h
+++ b/ObjectiveCloudant/ObjectiveCloudant.h
@@ -26,7 +26,17 @@ FOUNDATION_EXPORT const unsigned char ObjectiveCloudantVersionString[];
  * The types of index that can be used with
  * Cloudant Query.
  */
-typedef NS_ENUM(NSUInteger, CDTQueryIndexType) { CDTQueryIndexTypeJson };
+typedef NS_ENUM(NSUInteger, CDTQueryIndexType) {
+    /**
+        JSON index type.
+     */
+    CDTQueryIndexTypeJson,
+
+    /**
+        Text index type.
+     */
+    CDTQueryIndexTypeText
+};
 
 // In this header, you should import all the public headers of your framework
 // using statements like #import <ObjectiveCloudant/PublicHeader.h>

--- a/ObjectiveCloudant/Operations/CDTCreateQueryIndexOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCreateQueryIndexOperation.h
@@ -26,9 +26,49 @@
 
 /**
  *  The fields to be included in the index.
- *  Required: Needs to be set with a non zero length array.
+ *
+ *  For JSON Indexes, the syntax for specifying fields is Sort Syntax.
+ *
+ *  Example: `@[ @{ @"age": @"asc"} ]`
+ *
+ *  For Text indexes, you need to specify the data type for the field,
+ *  only `string`, `number`, or `boolean` are accepted.
+ *
+ *  Example: `@[ @{ @"name": @"age", @"type", @"number"} ]"
+ *
+ *
+ *  Required: fields are required for *JSON Indexes*
+ *  Optional: fields are optional for *Text Indexes*
+ *
+ * @see https://docs.cloudant.com/cloudant_query.html#creating-an-index
  **/
 @property (nullable, nonatomic, strong) NSArray<NSObject*>* fields;
+
+/**
+ * The name of the analyzer to use for $text operator with this index.
+ * Optional: CouchDb will use the default analyzer if one is not specified
+ * Note: text indexes only
+ **/
+@property (nullable, nonatomic, strong) NSString* defaultFieldAnalyzer;
+
+/**
+ * If the default field should be enabled for this index.
+ *
+ * If default field is disabled, the `$text` operator will
+ * return 0 results. If you wish to use the `$text` operator
+ * the index being created needs this option to be set to YES.
+ *
+ * Default: NO, default field index is disabled by default
+ * Note: text indexes only
+ */
+@property (nonatomic) BOOL defaultFieldEnabled;
+
+/**
+ * A selector to limit the documents in the index.
+ * Optional: If ommited all documents will be included in the index
+ * Note: text indexes only.
+ **/
+@property (nullable, nonatomic, strong) NSDictionary* selector;
 
 /**
  * The index type to use, deafults to json.

--- a/ObjectiveCloudantTests/CouchDBTests.m
+++ b/ObjectiveCloudantTests/CouchDBTests.m
@@ -9,7 +9,7 @@
 #import <XCTest/XCTest.h>
 #import <ObjectiveCloudant/ObjectiveCloudant.h>
 
-@interface CouchDB ()
+@interface CDTCouchDBClient ()
 
 @property NSString* username;
 @property NSString* password;
@@ -34,7 +34,8 @@
     components.user = username;
     components.password = password;
 
-    CouchDB* client = [CouchDB clientForURL:components.URL username:nil password:nil];
+    CDTCouchDBClient* client =
+        [CDTCouchDBClient clientForURL:components.URL username:nil password:nil];
 
     XCTAssertEqualObjects(username, client.username);
     XCTAssertEqualObjects(password, client.password);

--- a/ObjectiveCloudantTests/CreateIndexTests.m
+++ b/ObjectiveCloudantTests/CreateIndexTests.m
@@ -323,4 +323,271 @@
                                  }];
 }
 
+- (void)testIndexCreationFailsUsingTextParamsWithJson
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @"foo", @"bar" ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldAnalyzer = @"spanish";
+    index.defaultFieldEnabled = YES;
+    index.indexType = CDTQueryIndexTypeJson;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsUsingSortSyntaxFields
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @"foo", @"bar" ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldAnalyzer = @"spanish";
+    index.defaultFieldEnabled = YES;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationPassesWithNilfieldsTextIndex
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = nil;
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldAnalyzer = @"spanish";
+    index.defaultFieldEnabled = YES;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationPassesWithDefaultFieldDisabled
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = nil;
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationPassesWithTextFieldSpecifiedTypeString
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"name" : @"day", @"type" : @"string" } ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationPassesWithTextFieldSpecifiedTypeBoolean
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"name" : @"completed", @"type" : @"boolean" } ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationPassesWithTextFieldSpecifiedTypeNumber
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"name" : @"year", @"type" : @"number" } ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithTextFieldSpecifiedTypeText
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"name" : @"day", @"type" : @"text" } ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithTextFieldSpecifiedInSortSyntax
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"day" : @"asc" } ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithJSONFieldSpecifiedInTextSyntax
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"name" : @"day", @"type" : @"boolean" } ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeJson;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithTextFieldSpecifiedWithTooManyKeys
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"name" : @"day", @"type" : @"boolean", @"oneTooMany" : @(YES) } ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
+- (void)testIndexCreationFailsWithTextFieldSpecifiedWithTooFewKeys
+{
+    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
+    index.fields = @[ @{ @"name" : @"day" } ];
+    index.selector = @{ @"foo" : @"bar" };
+    index.defaultFieldEnabled = NO;
+    index.indexType = CDTQueryIndexTypeText;
+    XCTestExpectation *create = [self expectationWithDescription:@"Create index test"];
+    index.createIndexCompletionBlock = ^(NSError *error) {
+      [create fulfill];
+      XCTAssertNotNil(error);
+
+    };
+
+    [self.database addOperation:index];
+
+    [self waitForExpectationsWithTimeout:10
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Failed create index");
+                                 }];
+}
+
 @end

--- a/ObjectiveCloudantTests/ObjectiveCloudantTests.m
+++ b/ObjectiveCloudantTests/ObjectiveCloudantTests.m
@@ -167,8 +167,8 @@
                            body:@{
                                @"Hello" : @"World"
                            }
-              completionHandler:^(NSInteger statusCode, NSString *_Nullable docId,
-                                  NSString *_Nullable revId, NSError *_Nullable operationError) {
+              completionHandler:^(NSString *_Nullable docId, NSString *_Nullable revId,
+                                  NSInteger statusCode, NSError *_Nullable operationError) {
                 [firstRevCreate fulfill];
                 XCTAssertNil(operationError);
                 revision = revId;
@@ -188,8 +188,8 @@
                                @"Hello" : @"World",
                                @"Updated" : @(YES)
                            }
-              completionHandler:^(NSInteger statusCode, NSString *_Nullable docId,
-                                  NSString *_Nullable revId, NSError *_Nullable operationError) {
+              completionHandler:^(NSString *_Nullable docId, NSString *_Nullable revId,
+                                  NSInteger statusCode, NSError *_Nullable operationError) {
                 [secondRevCreate fulfill];
                 XCTAssertNil(operationError);
               }];


### PR DESCRIPTION
## How

Add additional functionality to CDTCreateQueryIndexOperation to handle the creation of text indexes. This does bring in some repeated code around validation of sort syntax. However PR #12 brings in a validator class, which should be used here.
## Testing

Test are found in the CreateIndexTests.m file
## Usage

``` objc
    CDTCreateQueryIndexOperation *index = [[CDTCreateQueryIndexOperation alloc] init];
    index.fields = @[ @{ @"day" : @"asc" } ];
    index.selector = @{ @"foo" : @"bar" };
    index.defaultFieldEnabled = NO;
    index.indexType = CDTQueryIndexTypeText;
    index.createIndexCompletionBlock = ^(NSError *error) {
         if(error){ /* encountered an error */ return}

        //do something about it completing
    };
    [self.database addOperation:index];
```
