### PR TITLE
Add missing convenience methods

### DIFF
--- a/ObjectiveCloudant/CDTDatabase.h
+++ b/ObjectiveCloudant/CDTDatabase.h
@@ -103,4 +103,78 @@
                                             NSInteger statusCode,
                                             NSError *_Nullable operationError))completionHandler;
 
+/**
+ Convenience method for creating a JSON Query Index.
+
+ Use CDTCreateQueryIndexOperation for greater control.
+
+ @param indexName the name of the index to create
+ @param fields the fields to be indexed
+ @param completionHandler a block to call when the operation has been completed
+ */
+- (void)createJSONQueryIndexWithName:(nonnull NSString *)indexName
+                              fields:(nonnull NSArray<NSObject *> *)fields
+                   completionHandler:
+                       (void (^_Nonnull)(NSError *_Nullable operationError))completionHandler;
+
+/**
+ Convience method for creating a Text Query Index
+
+ Use CDTCreateQueryIndexOperation for greater control.
+
+ @param indexName the name of the index to create
+ @param fields the fields to be indexed
+ @param completionHandler a block to call when the operation has been completed
+ */
+- (void)createTextQueryIndexWithname:(nonnull NSString *)indexName
+                              fields:(nonnull NSArray<NSObject *> *)fields
+                   completionHandler:
+                       (void (^_Nonnull)(NSError *_Nullable operationError))completionHandler;
+
+/**
+ Convenience method for finding documents using Cloudant Query
+
+ Use CDTQueryFindDocumentsOperation for greater control.
+
+ @param selector the selector to use to find documents
+ @param documentHandler code block to run for each document found to match the selector
+ @param completionHandler code block to run when the operation is complete
+ */
+- (void)findDocumentsUsingSeletor:(nonnull NSDictionary<NSString *, NSObject *> *)selector
+                  documentHandler:
+                      (void (^_Nonnull)(NSDictionary<NSString *, NSObject *> *_Nonnull document))
+                          documentHandler
+                completionHandler:(void (^_Nonnull)(NSString *_Nullable bookmark,
+                                                    NSError *_Nullable error))completionHandler;
+
+/**
+ Convenience method for deleting Cloudant Query JSON indexes
+
+ Use CDTDeleteQueryIndexOperation for greater control.
+
+ @param indexname the name of the index tot delete
+ @param designDocumentName the name of the design document that contains the index
+ @param completionHander a block to run when the operation completes
+ */
+- (void)deleteJSONQueryIndexWithName:(nonnull NSString *)indexName
+                  designDocumentName:(nonnull NSString *)designDocumentName
+                   completionHandler:
+                       (void (^_Nonnull)(NSInteger status,
+                                         NSError *_Nullable operationError))completionHandler;
+
+/**
+ Convenience method for deleting Cloudant Query Text indexes
+
+ Use CDTDeleteQueryIndexOperation for greater control.
+
+ @param indexname the name of the index tot delete
+ @param designDocumentName the name of the design document that contains the index
+ @param completionHander a block to run when the operation completes
+ */
+- (void)deleteTextQueryIndexWithName:(nonnull NSString *)indexName
+                  designDocumentName:(nonnull NSString *)designDocumentName
+                   completionHandler:
+                       (void (^_Nonnull)(NSInteger status,
+                                         NSError *_Nullable operationError))completionHandler;
+
 @end

--- a/ObjectiveCloudant/CDTDatabase.m
+++ b/ObjectiveCloudant/CDTDatabase.m
@@ -135,4 +135,63 @@
     [self addOperation:op];
 }
 
+- (void)createJSONQueryIndexWithName:(NSString *)indexName
+                              fields:(NSArray<NSObject *> *)fields
+                   completionHandler:(void (^)(NSError *_Nullable))completionHandler
+{
+    CDTCreateQueryIndexOperation *op = [[CDTCreateQueryIndexOperation alloc] init];
+    op.indexName = indexName;
+    op.fields = fields;
+    op.indexType = CDTQueryIndexTypeJson;
+    op.createIndexCompletionBlock = completionHandler;
+    [self addOperation:op];
+}
+
+- (void)createTextQueryIndexWithname:(NSString *)indexName
+                              fields:(NSArray<NSObject *> *)fields
+                   completionHandler:(void (^)(NSError *_Nullable))completionHandler
+{
+    CDTCreateQueryIndexOperation *op = [[CDTCreateQueryIndexOperation alloc] init];
+    op.indexName = indexName;
+    op.indexType = CDTQueryIndexTypeText;
+    op.defaultFieldEnabled = NO;
+    [self addOperation:op];
+}
+
+- (void)
+findDocumentsUsingSeletor:(NSDictionary<NSString *, NSObject *> *)selector
+          documentHandler:(void (^)(NSDictionary<NSString *, NSObject *> *_Nonnull))documentHandler
+        completionHandler:(void (^)(NSString *_Nullable, NSError *_Nullable))completionHandler
+{
+    CDTQueryFindDocumentsOperation *op = [[CDTQueryFindDocumentsOperation alloc] init];
+    op.selector = selector;
+    op.documentFoundBlock = documentHandler;
+    op.findDocumentsCompletionBlock = completionHandler;
+    [self addOperation:op];
+}
+
+- (void)deleteJSONQueryIndexWithName:(NSString *)indexName
+                  designDocumentName:(NSString *)designDocumentName
+                   completionHandler:(void (^)(NSInteger, NSError *_Nullable))completionHandler
+{
+    CDTDeleteQueryIndexOperation *op = [[CDTDeleteQueryIndexOperation alloc] init];
+    op.indexName = indexName;
+    op.indexType = CDTQueryIndexTypeJson;
+    op.desginDocName = designDocumentName;
+    op.deleteIndexCompletionBlock = completionHandler;
+    [self addOperation:op];
+}
+
+- (void)deleteTextQueryIndexWithName:(NSString *)indexName
+                  designDocumentName:(NSString *)designDocumentName
+                   completionHandler:(void (^)(NSInteger, NSError *_Nullable))completionHandler
+{
+    CDTDeleteQueryIndexOperation *op = [[CDTDeleteQueryIndexOperation alloc] init];
+    op.indexName = indexName;
+    op.desginDocName = designDocumentName;
+    op.indexType = CDTQueryIndexTypeText;
+    op.deleteIndexCompletionBlock = completionHandler;
+    [self addOperation:op];
+}
+
 @end

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -53,11 +53,11 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
     /**
      Deleting a document failed.
      */
-    CDTObjectiveCloudantErrorDeleteDocumentFailed
+    CDTObjectiveCloudantErrorDeleteDocumentFailed,
 
-     /*
-     Finding documents failed.
-     */
+    /*
+    Finding documents failed.
+    */
     CDTObjectiveCloudantErrorFindDocumentsFailed
 };
 

--- a/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
@@ -98,6 +98,7 @@
                                   errorWithDomain:CDTObjectiveCloudantErrorDomain
                                              code:CDTObjectiveCloudantErrorGetDocumentFailed
                                          userInfo:userInfo];
+                              self.getDocumentCompletionBlock(result, error);
                           }
 
                           if (self && self.getDocumentCompletionBlock) {


### PR DESCRIPTION
Adds missing convenience methods to `CDTDatabase`.

`CDTDatabase` now supports all CRUD actions for documents, `Create` and `Delete` actions for query indexes and finding documents via query.
