### PR TITLE
Extract request builder

### DIFF
--- a/ObjectiveCloudant.xcodeproj/project.pbxproj
+++ b/ObjectiveCloudant.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		275B9CCE1BA9D3540023CB63 /* CDTPutDocumentOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 275B9CCC1BA9D3540023CB63 /* CDTPutDocumentOperation.m */; };
 		275B9CD01BA9D3770023CB63 /* PutDocumentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 275B9CCF1BA9D3770023CB63 /* PutDocumentTests.m */; };
 		279E8D331B7F905B001100D4 /* ObjectiveCloudant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 279E8D281B7F905B001100D4 /* ObjectiveCloudant.framework */; };
+		27BC070B1C0459E4009C6440 /* CDTOperationRequestBuilderDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BC070A1C04588D009C6440 /* CDTOperationRequestBuilderDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27F6B7211BA9C266000B523E /* TestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F6B71E1BA9C243000B523E /* TestHelpers.m */; };
 		27F6B7241BA9C322000B523E /* CDTCreateDatabaseOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 27F6B7221BA9C322000B523E /* CDTCreateDatabaseOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27F6B7251BA9C322000B523E /* CDTCreateDatabaseOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F6B7231BA9C322000B523E /* CDTCreateDatabaseOperation.m */; };
@@ -99,6 +100,7 @@
 		275B9CCF1BA9D3770023CB63 /* PutDocumentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PutDocumentTests.m; path = ObjectiveCloudantTests/PutDocumentTests.m; sourceTree = SOURCE_ROOT; };
 		279E8D281B7F905B001100D4 /* ObjectiveCloudant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectiveCloudant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		279E8D321B7F905B001100D4 /* ObjectiveCloudant.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectiveCloudant.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		27BC070A1C04588D009C6440 /* CDTOperationRequestBuilderDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CDTOperationRequestBuilderDelegate.h; path = ObjectiveCloudant/HTTP/CDTOperationRequestBuilderDelegate.h; sourceTree = SOURCE_ROOT; };
 		27F6B71D1BA9C243000B523E /* TestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestHelpers.h; path = ObjectiveCloudantTests/TestHelpers.h; sourceTree = SOURCE_ROOT; };
 		27F6B71E1BA9C243000B523E /* TestHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestHelpers.m; path = ObjectiveCloudantTests/TestHelpers.m; sourceTree = SOURCE_ROOT; };
 		27F6B7221BA9C322000B523E /* CDTCreateDatabaseOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTCreateDatabaseOperation.h; path = ObjectiveCloudant/Operations/CDTCreateDatabaseOperation.h; sourceTree = SOURCE_ROOT; };
@@ -289,6 +291,7 @@
 				984AA6321BAAFA08003D4DCA /* CDTURLSessionTask.m */,
 				273EF55D1C00B870009A09E3 /* CDTOperationRequestBuilder.h */,
 				273EF55E1C00B870009A09E3 /* CDTOperationRequestBuilder.m */,
+				27BC070A1C04588D009C6440 /* CDTOperationRequestBuilderDelegate.h */,
 			);
 			name = HTTP;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 				984AA6331BAAFA08003D4DCA /* CDTHTTPInterceptor.h in Headers */,
 				984AA63D1BAAFA08003D4DCA /* CDTURLSessionTask.h in Headers */,
 				984AA65B1BAFF8C4003D4DCA /* CDTDeleteDocumentOperation.h in Headers */,
+				27BC070B1C0459E4009C6440 /* CDTOperationRequestBuilderDelegate.h in Headers */,
 				274CF67D1B9055B9008BBD50 /* CDTGetDocumentOperation.h in Headers */,
 				9851D1781BC57C2700145176 /* CDTQueryFindDocumentsOperation.h in Headers */,
 				274CF6751B9055B9008BBD50 /* CDTDatabase.h in Headers */,

--- a/ObjectiveCloudant.xcodeproj/project.pbxproj
+++ b/ObjectiveCloudant.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		273EF55F1C00B870009A09E3 /* CDTOperationRequestBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 273EF55D1C00B870009A09E3 /* CDTOperationRequestBuilder.h */; settings = {ASSET_TAGS = (); }; };
+		273EF5601C00B870009A09E3 /* CDTOperationRequestBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 273EF55E1C00B870009A09E3 /* CDTOperationRequestBuilder.m */; settings = {ASSET_TAGS = (); }; };
 		274CF6731B9055B9008BBD50 /* CDTCouchDBClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 274CF6661B9055B9008BBD50 /* CDTCouchDBClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		274CF6741B9055B9008BBD50 /* CDTCouchDBClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 274CF6671B9055B9008BBD50 /* CDTCouchDBClient.m */; };
 		274CF6751B9055B9008BBD50 /* CDTDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 274CF6681B9055B9008BBD50 /* CDTDatabase.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -76,6 +78,8 @@
 
 /* Begin PBXFileReference section */
 		2475D3C3038B0291D094C46B /* Pods-ObjectiveCloudantTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectiveCloudantTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectiveCloudantTests/Pods-ObjectiveCloudantTests.release.xcconfig"; sourceTree = "<group>"; };
+		273EF55D1C00B870009A09E3 /* CDTOperationRequestBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTOperationRequestBuilder.h; path = ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.h; sourceTree = SOURCE_ROOT; };
+		273EF55E1C00B870009A09E3 /* CDTOperationRequestBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTOperationRequestBuilder.m; path = ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.m; sourceTree = SOURCE_ROOT; };
 		274CF6661B9055B9008BBD50 /* CDTCouchDBClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTCouchDBClient.h; path = ObjectiveCloudant/CDTCouchDBClient.h; sourceTree = SOURCE_ROOT; };
 		274CF6671B9055B9008BBD50 /* CDTCouchDBClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTCouchDBClient.m; path = ObjectiveCloudant/CDTCouchDBClient.m; sourceTree = SOURCE_ROOT; };
 		274CF6681B9055B9008BBD50 /* CDTDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTDatabase.h; path = ObjectiveCloudant/CDTDatabase.h; sourceTree = SOURCE_ROOT; };
@@ -283,6 +287,8 @@
 				984AA6301BAAFA08003D4DCA /* CDTInterceptableSession.m */,
 				984AA6311BAAFA08003D4DCA /* CDTURLSessionTask.h */,
 				984AA6321BAAFA08003D4DCA /* CDTURLSessionTask.m */,
+				273EF55D1C00B870009A09E3 /* CDTOperationRequestBuilder.h */,
+				273EF55E1C00B870009A09E3 /* CDTOperationRequestBuilder.m */,
 			);
 			name = HTTP;
 			sourceTree = "<group>";
@@ -307,6 +313,7 @@
 				274CF6791B9055B9008BBD50 /* CDTCouchDatabaseOperation.h in Headers */,
 				274CF6731B9055B9008BBD50 /* CDTCouchDBClient.h in Headers */,
 				274CF67B1B9055B9008BBD50 /* CDTCouchOperation.h in Headers */,
+				273EF55F1C00B870009A09E3 /* CDTOperationRequestBuilder.h in Headers */,
 				274CF6781B9055B9008BBD50 /* ObjectiveCloudant.h in Headers */,
 				275B9CCD1BA9D3540023CB63 /* CDTPutDocumentOperation.h in Headers */,
 				984AA6371BAAFA08003D4DCA /* CDTSessionCookieInterceptor.h in Headers */,
@@ -489,6 +496,7 @@
 				27F6B7251BA9C322000B523E /* CDTCreateDatabaseOperation.m in Sources */,
 				27F6B72B1BA9C98C000B523E /* CDTDeleteDatabaseOperation.m in Sources */,
 				274CF6761B9055B9008BBD50 /* CDTDatabase.m in Sources */,
+				273EF5601C00B870009A09E3 /* CDTOperationRequestBuilder.m in Sources */,
 				984AA65C1BAFF8C4003D4DCA /* CDTDeleteDocumentOperation.m in Sources */,
 				980B2BF81BC27CC800CD40F8 /* CDTDeleteQueryIndexOperation.m in Sources */,
 				98629D681BB40EF900E7F5E8 /* CDTCouchOperation+internal.m in Sources */,

--- a/ObjectiveCloudant/CDTCouchDBClient.m
+++ b/ObjectiveCloudant/CDTCouchDBClient.m
@@ -45,7 +45,7 @@
     return [[CDTCouchDBClient alloc] initForURL:url username:username password:password];
 }
 
-- (nullable instancetype)initForURL:(nullable NSURL *)url
+- (nullable instancetype)initForURL:(nonnull NSURL *)url
                            username:(nullable NSString *)username
                            password:(nullable NSString *)password
 {

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.h
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.h
@@ -21,8 +21,9 @@
 
 @interface CDTOperationRequestBuilder : NSObject
 
-- (instancetype)initWithOperation:(NSOperation<CDTOperationRequestBuilderDelegate> *)operation;
+- (nullable instancetype)initWithOperation:
+    (nonnull NSOperation<CDTOperationRequestBuilderDelegate> *)operation;
 
-- (NSURLRequest *)buildRequest;
+- (nonnull NSURLRequest *)buildRequest;
 
 @end

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.h
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.h
@@ -1,0 +1,27 @@
+//
+//  CDTOperationRequestBuilder.h
+//  ObjectiveCloudant
+//
+//  Created by Michael Rhodes on 21/11/2015.
+//  Copyright (c) IBM Corp. 2015
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+@class CDTCouchOperation;
+
+@interface CDTOperationRequestBuilder : NSObject
+
+- (instancetype)initWithOperation:(CDTCouchOperation *)operation;
+
+- (NSURLRequest *)buildRequest;
+
+@end

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.h
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.h
@@ -15,12 +15,13 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "CDTOperationRequestBuilderDelegate.h"
 
 @class CDTCouchOperation;
 
 @interface CDTOperationRequestBuilder : NSObject
 
-- (instancetype)initWithOperation:(CDTCouchOperation *)operation;
+- (instancetype)initWithOperation:(NSOperation<CDTOperationRequestBuilderDelegate> *)operation;
 
 - (NSURLRequest *)buildRequest;
 

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.m
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.m
@@ -1,0 +1,71 @@
+//
+//  CDTOperationRequestBuilder.m
+//  ObjectiveCloudant
+//
+//  Created by Michael Rhodes on 21/11/2015.
+//  Copyright (c) IBM Corp. 2015
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTOperationRequestBuilder.h"
+
+#import "CDTCouchOperation.h"
+
+@interface CDTOperationRequestBuilder ()
+
+@property (nonatomic, strong) NSURL *rootURL;
+@property (nonatomic, strong) NSString *path;
+@property (nonatomic, strong) NSString *method;
+@property (nonatomic, strong) NSArray *queryItems;
+@property (nonatomic, strong) NSData *body;
+
+@end
+
+@implementation CDTOperationRequestBuilder
+
+- (instancetype)initWithOperation:(CDTCouchOperation *)operation;
+{
+    self = [super init];
+    if (self) {
+        _rootURL = operation.rootURL;
+        _path = operation.httpPath;
+        _method = operation.httpMethod;
+        _queryItems = operation.queryItems;
+        _body = operation.httpRequestBody;
+    }
+    return self;
+}
+
+- (NSURLRequest *)buildRequest;
+{
+    NSURLComponents *components =
+        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
+
+    components.path = self.path;
+    components.queryItems = components.queryItems ? components.queryItems : @[];
+    components.queryItems = [components.queryItems arrayByAddingObjectsFromArray:self.queryItems];
+
+    NSLog(@"%@", [[components URL] absoluteString]);
+
+    NSMutableURLRequest *request =
+        [NSMutableURLRequest requestWithURL:[components URL]
+                                cachePolicy:NSURLRequestUseProtocolCachePolicy
+                            timeoutInterval:10.0];
+
+    [request setHTTPMethod:self.method];
+
+    if (self.body) {
+        request.HTTPBody = self.body;
+    }
+
+    return request;
+}
+
+@end

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.m
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.m
@@ -17,6 +17,7 @@
 #import "CDTOperationRequestBuilder.h"
 
 #import "CDTCouchOperation.h"
+#import "CDTOperationRequestBuilderDelegate.h"
 
 @interface CDTOperationRequestBuilder ()
 
@@ -30,15 +31,22 @@
 
 @implementation CDTOperationRequestBuilder
 
-- (instancetype)initWithOperation:(CDTCouchOperation *)operation;
+- (instancetype)initWithOperation:(NSOperation<CDTOperationRequestBuilderDelegate> *)operation;
 {
     self = [super init];
     if (self) {
+        // Required parts of CDTOperationRequestBuilderDelegate
+        _method = operation.httpMethod;
         _rootURL = operation.rootURL;
         _path = operation.httpPath;
-        _method = operation.httpMethod;
-        _queryItems = operation.queryItems;
-        _body = operation.httpRequestBody;
+
+        // Optional parts of CDTOperationRequestBuilderDelegate
+        if ([operation respondsToSelector:@selector(queryItems)]) {
+            _queryItems = operation.queryItems;
+        }
+        if ([operation respondsToSelector:@selector(httpRequestBody)]) {
+            _body = operation.httpRequestBody;
+        }
     }
     return self;
 }

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.m
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestBuilder.m
@@ -31,7 +31,8 @@
 
 @implementation CDTOperationRequestBuilder
 
-- (instancetype)initWithOperation:(NSOperation<CDTOperationRequestBuilderDelegate> *)operation;
+- (nullable instancetype)initWithOperation:
+    (nonnull NSOperation<CDTOperationRequestBuilderDelegate> *)operation;
 {
     self = [super init];
     if (self) {
@@ -51,7 +52,7 @@
     return self;
 }
 
-- (NSURLRequest *)buildRequest;
+- (nonnull NSURLRequest *)buildRequest;
 {
     NSURLComponents *components =
         [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestBuilderDelegate.h
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestBuilderDelegate.h
@@ -24,28 +24,28 @@
 /**
  Base URL for this operation.
  */
-- (NSURL *)rootURL;
+- (nonnull NSURL *)rootURL;
 
 /**
  URL path for this operation.
  */
-- (NSString *)httpPath;
+- (nonnull NSString *)httpPath;
 
 /**
  HTTP method for this operation.
  */
-- (NSString *)httpMethod;
+- (nonnull NSString *)httpMethod;
 
 @optional
 
 /**
  Query items for this operation.
  */
-- (NSArray<NSURLQueryItem *> *)queryItems;
+- (nonnull NSArray<NSURLQueryItem *> *)queryItems;
 
 /**
  Request body for this operation; return `nil` if no body (e.g., for GET).
  */
-- (NSData *)httpRequestBody;
+- (nonnull NSData *)httpRequestBody;
 
 @end

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestBuilderDelegate.h
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestBuilderDelegate.h
@@ -1,0 +1,51 @@
+//
+//  CDTOperationRequestBuilderDelegate.h
+//  ObjectiveCloudant
+//
+//  Created by Michael Rhodes on 24/11/2015.
+//  Copyright (c) 2015 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ Contains the methods required for using an NSOperation with CDTOperationRequestBuilder.
+ */
+@protocol CDTOperationRequestBuilderDelegate
+
+/**
+ Base URL for this operation.
+ */
+- (NSURL *)rootURL;
+
+/**
+ URL path for this operation.
+ */
+- (NSString *)httpPath;
+
+/**
+ HTTP method for this operation.
+ */
+- (NSString *)httpMethod;
+
+@optional
+
+/**
+ Query items for this operation.
+ */
+- (NSArray<NSURLQueryItem *> *)queryItems;
+
+/**
+ Request body for this operation; return `nil` if no body (e.g., for GET).
+ */
+- (NSData *)httpRequestBody;
+
+@end

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -102,9 +102,6 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
 /// @name Sub-class overrides
 /// ---------------------------------
 
-/** Extra query parameters to add to outgoing request. */
-@property (nullable, nonatomic, strong) NSArray<NSURLQueryItem *> *queryItems;
-
 /**
  An opportunity for subclasses to add items to headers, query string, POST body etc.
 

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -128,6 +128,27 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
  */
 - (void)callCompletionHandlerWithError:(nonnull NSError *)error;
 
+/**
+ URL path for this operation.
+
+ Should be overridden by subclasses to create appropriate path.
+ */
+@property (nonnull, nonatomic, readonly) NSString *httpPath;
+
+/**
+ HTTP method for this operation.
+
+ Should be overridden by subclasses to provide appropriate method.
+ */
+@property (nonnull, nonatomic, readonly) NSString *httpMethod;
+
+/**
+ Request body for this operation; return `nil` if no body (e.g., for GET).
+
+ Should be overridden by subclasses to provide request body data.
+ */
+@property (nullable, nonatomic, readonly) NSData *httpRequestBody;
+
 /// ---------------------------------
 /// @name Life-cycle management
 /// ---------------------------------

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -96,7 +96,7 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
 
  Must be set before a call can be successfully made.
  */
-@property (nullable, nonatomic, strong) NSURL *rootURL;
+@property (nonnull, nonatomic, strong) NSURL *rootURL;
 
 /// ---------------------------------
 /// @name Sub-class overrides

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 #import "CDTInterceptableSession.h"
+#import "CDTOperationRequestBuilderDelegate.h"
 
 /**
  The CDTObjectiveCloudantErrorDomain String
@@ -74,7 +75,7 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
 
  Centralises the HTTP connections made to Cloudant.
  */
-@interface CDTCouchOperation : NSOperation {
+@interface CDTCouchOperation : NSOperation <CDTOperationRequestBuilderDelegate> {
     BOOL executing;
     BOOL finished;
 }
@@ -127,27 +128,6 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
  Overrides should NOT call `completeOperation`.
  */
 - (void)callCompletionHandlerWithError:(nonnull NSError *)error;
-
-/**
- URL path for this operation.
-
- Should be overridden by subclasses to create appropriate path.
- */
-@property (nonnull, nonatomic, readonly) NSString *httpPath;
-
-/**
- HTTP method for this operation.
-
- Should be overridden by subclasses to provide appropriate method.
- */
-@property (nonnull, nonatomic, readonly) NSString *httpMethod;
-
-/**
- Request body for this operation; return `nil` if no body (e.g., for GET).
-
- Should be overridden by subclasses to provide request body data.
- */
-@property (nullable, nonatomic, readonly) NSData *httpRequestBody;
 
 /// ---------------------------------
 /// @name Life-cycle management

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.m
@@ -36,6 +36,10 @@ NSInteger const kCDTNoHTTPStatus = 0;
 
 - (void)callCompletionHandlerWithError:(NSError *)error { return; }
 
+- (NSString *)httpPath { return @"/"; }
+
+- (NSString *)httpMethod { return @"GET"; }
+
 #pragma mark Concurrent operation NSOperation functions
 
 - (id)init

--- a/ObjectiveCloudant/Operations/CDTCreateDatabaseOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCreateDatabaseOperation.m
@@ -15,6 +15,7 @@
 
 #import "CDTCreateDatabaseOperation.h"
 #import "CDTCouchOperation+internal.h"
+#import "CDTOperationRequestBuilder.h"
 
 @implementation CDTCreateDatabaseOperation
 
@@ -26,27 +27,16 @@
     }
 }
 
+- (NSString *)httpPath { return [NSString stringWithFormat:@"/%@", self.databaseName]; }
+
+- (NSString *)httpMethod { return @"PUT"; }
+
 #pragma mark Instance methods
 
 - (void)dispatchAsyncHttpRequest
 {
-    NSString *path = [NSString stringWithFormat:@"/%@", self.databaseName];
-
-    NSURLComponents *components =
-        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
-
-    components.path = path;
-    components.queryItems = components.queryItems ? components.queryItems : @[];
-    components.queryItems = [components.queryItems arrayByAddingObjectsFromArray:self.queryItems];
-
-    NSLog(@"%@", [[components URL] absoluteString]);
-
-    NSMutableURLRequest *request =
-        [NSMutableURLRequest requestWithURL:[components URL]
-                                cachePolicy:NSURLRequestUseProtocolCachePolicy
-                            timeoutInterval:10.0];
-
-    [request setHTTPMethod:@"PUT"];
+    CDTOperationRequestBuilder *b = [[CDTOperationRequestBuilder alloc] initWithOperation:self];
+    NSURLRequest *request = [b buildRequest];
 
     __weak CDTCreateDatabaseOperation *weakSelf = self;
     self.task = [self.session

--- a/ObjectiveCloudant/Operations/CDTCreateQueryIndexOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCreateQueryIndexOperation.m
@@ -16,6 +16,7 @@
 #import "CDTCreateQueryIndexOperation.h"
 #import "CDTSortSyntaxValidator.h"
 #import "CDTCouchOperation+internal.h"
+#import "CDTOperationRequestBuilder.h"
 
 // Testing this class will need to mock the entire query back end,
 // XCTest doesn't provide a way to skip tests based on conditions
@@ -154,6 +155,12 @@
     return (self.jsonBody != nil);
 }
 
+- (NSString *)httpPath { return [NSString stringWithFormat:@"/%@/_index", self.databaseName]; }
+
+- (NSString *)httpMethod { return @"POST"; }
+
+- (NSData *)httpRequestBody { return self.jsonBody; }
+
 - (void)callCompletionHandlerWithError:(NSError *)error
 {
     if (self.createIndexCompletionBlock) {
@@ -163,21 +170,8 @@
 
 - (void)dispatchAsyncHttpRequest
 {
-    NSString *path = [NSString stringWithFormat:@"/%@/_index", self.databaseName];
-
-    NSURLComponents *components =
-        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
-    components.path = path;
-
-    NSLog(@"%@", [[components URL] absoluteString]);
-
-    NSMutableURLRequest *request =
-        [NSMutableURLRequest requestWithURL:components.URL
-                                cachePolicy:NSURLRequestUseProtocolCachePolicy
-                            timeoutInterval:10.0];
-    request.HTTPMethod = @"POST";
-    request.HTTPBody = self.jsonBody;
-
+    CDTOperationRequestBuilder *b = [[CDTOperationRequestBuilder alloc] initWithOperation:self];
+    NSURLRequest *request = [b buildRequest];
     self.request = request;
 
     __weak CDTCreateQueryIndexOperation *weakSelf = self;

--- a/ObjectiveCloudant/Operations/CDTDeleteDatabaseOperation.m
+++ b/ObjectiveCloudant/Operations/CDTDeleteDatabaseOperation.m
@@ -15,6 +15,7 @@
 
 #import "CDTDeleteDatabaseOperation.h"
 #import "CDTCouchOperation+internal.h"
+#import "CDTOperationRequestBuilder.h"
 
 @implementation CDTDeleteDatabaseOperation
 
@@ -29,25 +30,14 @@
     }
 }
 
+- (NSString *)httpPath { return [NSString stringWithFormat:@"/%@", self.databaseName]; }
+
+- (NSString *)httpMethod { return @"DELETE"; }
+
 - (void)dispatchAsyncHttpRequest
 {
-    NSString *path = [NSString stringWithFormat:@"/%@", self.databaseName];
-
-    NSURLComponents *components =
-        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
-
-    components.path = path;
-    components.queryItems = components.queryItems ? components.queryItems : @[];
-    components.queryItems = [components.queryItems arrayByAddingObjectsFromArray:self.queryItems];
-
-    NSLog(@"%@", [[components URL] absoluteString]);
-
-    NSMutableURLRequest *request =
-        [NSMutableURLRequest requestWithURL:[components URL]
-                                cachePolicy:NSURLRequestUseProtocolCachePolicy
-                            timeoutInterval:10.0];
-
-    [request setHTTPMethod:@"DELETE"];
+    CDTOperationRequestBuilder *b = [[CDTOperationRequestBuilder alloc] initWithOperation:self];
+    NSURLRequest *request = [b buildRequest];
 
     __weak CDTDeleteDatabaseOperation *weakSelf = self;
     self.task = [self.session

--- a/ObjectiveCloudant/Operations/CDTDeleteDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTDeleteDocumentOperation.m
@@ -16,6 +16,7 @@
 //
 
 #import "CDTDeleteDocumentOperation.h"
+#import "CDTOperationRequestBuilder.h"
 
 @interface CDTDeleteDocumentOperation ()
 
@@ -44,25 +45,19 @@
     }
 }
 
+- (NSString *)httpPath
+{
+    return [NSString stringWithFormat:@"/%@/%@", self.databaseName, self.docId];
+}
+
+- (NSString *)httpMethod { return @"DELETE"; }
+
 #pragma mark Instance methods
 
 - (void)dispatchAsyncHttpRequest
 {
-    NSString *path = [NSString stringWithFormat:@"/%@/%@", self.databaseName, self.docId];
-
-    NSURLComponents *components =
-        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
-
-    components.path = path;
-    components.queryItems = components.queryItems ? components.queryItems : @[];
-    components.queryItems = [components.queryItems arrayByAddingObjectsFromArray:self.queryItems];
-
-    NSMutableURLRequest *request =
-        [NSMutableURLRequest requestWithURL:components.URL
-                                cachePolicy:NSURLRequestUseProtocolCachePolicy
-                            timeoutInterval:10.0];
-
-    [request setHTTPMethod:@"DELETE"];
+    CDTOperationRequestBuilder *b = [[CDTOperationRequestBuilder alloc] initWithOperation:self];
+    NSURLRequest *request = [b buildRequest];
 
     __weak CDTDeleteDocumentOperation *weakSelf = self;
     self.task = [self.session

--- a/ObjectiveCloudant/Operations/CDTDeleteDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTDeleteDocumentOperation.m
@@ -30,12 +30,16 @@
 {
     if ([super buildAndValidate]) {
         if (self.revId && self.docId) {
-            self.queryItems = @[ [NSURLQueryItem queryItemWithName:@"rev" value:self.revId] ];
             return YES;
         }
     }
 
     return NO;
+}
+
+- (NSArray<NSURLQueryItem *> *)queryItems
+{
+    return @[ [NSURLQueryItem queryItemWithName:@"rev" value:self.revId] ];
 }
 
 - (void)callCompletionHandlerWithError:(NSError *)error

--- a/ObjectiveCloudant/Operations/CDTDeleteQueryIndexOperation.m
+++ b/ObjectiveCloudant/Operations/CDTDeleteQueryIndexOperation.m
@@ -15,6 +15,7 @@
 
 #import "CDTDeleteQueryIndexOperation.h"
 #import "CDTCouchOperation+internal.h"
+#import "CDTOperationRequestBuilder.h"
 
 @implementation CDTDeleteQueryIndexOperation
 
@@ -50,20 +51,20 @@
     return YES;
 }
 
-- (void)dispatchAsyncHttpRequest
+- (NSString *)httpPath
 {
     // currently the only supported type.
     NSString *indexType = @"json";
+    return [NSString stringWithFormat:@"/%@/_index/%@/%@/%@", self.databaseName, self.designDocName,
+                                      indexType, self.indexName];
+}
 
-    NSString *path = [NSString stringWithFormat:@"/%@/_index/%@/%@/%@", self.databaseName,
-                                                self.designDocName, indexType, self.indexName];
+- (NSString *)httpMethod { return @"DELETE"; }
 
-    NSURLComponents *components =
-        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
-    components.path = path;
-
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:components.URL];
-    request.HTTPMethod = @"DELETE";
+- (void)dispatchAsyncHttpRequest
+{
+    CDTOperationRequestBuilder *b = [[CDTOperationRequestBuilder alloc] initWithOperation:self];
+    NSURLRequest *request = [b buildRequest];
 
     __weak CDTDeleteQueryIndexOperation *weakSelf = self;
     self.task = [self.session

--- a/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
@@ -24,19 +24,22 @@
 {
     if ([super buildAndValidate]) {
         if (self.docId) {
-            NSMutableArray *queryItems = [NSMutableArray array];
-            [queryItems
-                addObject:[NSURLQueryItem queryItemWithName:@"revs"
-                                                      value:(self.revs ? @"true" : @"false")]];
-            if (self.revId) {
-                [queryItems addObject:[NSURLQueryItem queryItemWithName:@"rev" value:self.revId]];
-            }
-            self.queryItems = [queryItems copy];
             return YES;
         }
     }
 
     return NO;
+}
+
+- (NSArray<NSURLQueryItem *> *)queryItems
+{
+    NSMutableArray *queryItems = [NSMutableArray array];
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:@"revs"
+                                                      value:(self.revs ? @"true" : @"false")]];
+    if (self.revId) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"rev" value:self.revId]];
+    }
+    return [NSArray arrayWithArray:queryItems];
 }
 
 - (NSString *)httpPath

--- a/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTGetDocumentOperation.m
@@ -16,6 +16,7 @@
 
 #import "CDTGetDocumentOperation.h"
 #import "CDTCouchOperation+internal.h"
+#import "CDTOperationRequestBuilder.h"
 
 @implementation CDTGetDocumentOperation
 
@@ -38,6 +39,13 @@
     return NO;
 }
 
+- (NSString *)httpPath
+{
+    return [NSString stringWithFormat:@"/%@/%@", self.databaseName, self.docId];
+}
+
+- (NSString *)httpMethod { return @"GET"; }
+
 #pragma mark Instance methods
 
 - (void)callCompletionHandlerWithError:(NSError *)error
@@ -49,23 +57,8 @@
 
 - (void)dispatchAsyncHttpRequest
 {
-    NSString *path = [NSString stringWithFormat:@"/%@/%@", self.databaseName, self.docId];
-
-    NSURLComponents *components =
-        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
-
-    components.path = path;
-    components.queryItems = components.queryItems ? components.queryItems : @[];
-    components.queryItems = [components.queryItems arrayByAddingObjectsFromArray:self.queryItems];
-
-    NSLog(@"%@", [[components URL] absoluteString]);
-
-    NSMutableURLRequest *request =
-        [NSMutableURLRequest requestWithURL:[components URL]
-                                cachePolicy:NSURLRequestUseProtocolCachePolicy
-                            timeoutInterval:10.0];
-
-    [request setHTTPMethod:@"GET"];
+    CDTOperationRequestBuilder *b = [[CDTOperationRequestBuilder alloc] initWithOperation:self];
+    NSURLRequest *request = [b buildRequest];
 
     __weak CDTGetDocumentOperation *weakSelf = self;
     self.task =

--- a/ObjectiveCloudant/Operations/CDTPutDocumentOperation.m
+++ b/ObjectiveCloudant/Operations/CDTPutDocumentOperation.m
@@ -23,18 +23,21 @@
 {
     if ([super buildAndValidate]) {
         if (self.docId && self.body && [NSJSONSerialization isValidJSONObject:self.body]) {
-            NSMutableArray *tmp = [NSMutableArray array];
-
-            if (self.revId) {
-                [tmp addObject:[NSURLQueryItem queryItemWithName:@"rev" value:self.revId]];
-            }
-
-            self.queryItems = [NSArray arrayWithArray:tmp];
-
             return YES;
         }
     }
     return NO;
+}
+
+- (NSArray<NSURLQueryItem *> *)queryItems
+{
+    NSMutableArray *tmp = [NSMutableArray array];
+
+    if (self.revId) {
+        [tmp addObject:[NSURLQueryItem queryItemWithName:@"rev" value:self.revId]];
+    }
+
+    return [NSArray arrayWithArray:tmp];
 }
 
 - (NSString *)httpPath

--- a/ObjectiveCloudant/Operations/CDTQueryFindDocumentsOperation.m
+++ b/ObjectiveCloudant/Operations/CDTQueryFindDocumentsOperation.m
@@ -16,6 +16,7 @@
 #import "CDTQueryFindDocumentsOperation.h"
 #import "CDTSortSyntaxValidator.h"
 #import "CDTCouchOperation+internal.h"
+#import "CDTOperationRequestBuilder.h"
 
 /**
  * Value that indicates no value is set for an integer parameter
@@ -102,17 +103,16 @@ NSInteger const kCDTDefaultOperationIntegerValue = -1;
     return YES;
 }
 
+- (NSString *)httpPath { return [NSString stringWithFormat:@"/%@/_find", self.databaseName]; }
+
+- (NSString *)httpMethod { return @"POST"; }
+
+- (NSData *)httpRequestBody { return self.jsonBody; }
+
 - (void)dispatchAsyncHttpRequest
 {
-    NSString *path = [NSString stringWithFormat:@"/%@/_find", self.databaseName];
-
-    NSURLComponents *components =
-        [NSURLComponents componentsWithURL:self.rootURL resolvingAgainstBaseURL:NO];
-    components.path = path;
-
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:components.URL];
-    request.HTTPMethod = @"POST";
-    request.HTTPBody = self.jsonBody;
+    CDTOperationRequestBuilder *b = [[CDTOperationRequestBuilder alloc] initWithOperation:self];
+    NSURLRequest *request = [b buildRequest];
 
     __weak CDTQueryFindDocumentsOperation *weakSelf = self;
 


### PR DESCRIPTION
# What

The operations in Objective-Cloudant have a lot of copy and paste code
used to build requests. This commit introduces a builder for the
NSURLRequest used to make the request to Cloudant. The idea is to remove
boilerplate code from the operations, in order to bring each operation
closer to the ideal of having only the code it needs and no more.

# How

The builder takes a CDTCouchOperation in its constructor. The
CDTCouchOperation has been updated to expose information required to
build the HTTP request as properties. Subclasses are expected to
override these properties as required for their specific requests.
For example, all operations will override the `httpPath` property.
The builder reads this information into private properties at init
time which are later used to build the request.

# Testing

This is a refactor; no new tests were added. We could add some tests for the new class, but I'm not sure they're necessary.

# Reviewers

reviewer @rhyshort