### PR TITLE
Extract common request-making code for operations into executor class

### DIFF
--- a/CDTOperationRequestExecutorDelegate.h
+++ b/CDTOperationRequestExecutorDelegate.h
@@ -1,0 +1,53 @@
+//
+//  CDTOperationRequestBuilderDelegate.h
+//  ObjectiveCloudant
+//
+//  Created by Michael Rhodes on 24/11/2015.
+//  Copyright (c) 2015 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTOperationRequestBuilderDelegate.h"
+
+@class CDTInterceptableSession;
+
+/**
+ Contains the methods required for using an NSOperation with CDTOperationRequestBuilder.
+ */
+@protocol CDTOperationRequestExecutorDelegate <CDTOperationRequestBuilderDelegate>
+
+/**
+ Returns the session used to make HTTP requests.
+ */
+- (nonnull CDTInterceptableSession *)session;
+
+/**
+ Should execute necessary NSOperation completion KVO work.
+ */
+- (void)completeOperation;
+
+@optional
+
+/**
+ This callback should do operation-specific processing of the
+ request content. It need not worry about NSOperation lifecycle.
+ 
+ It doesn't need to check whether the operation was cancelled, or
+ call the CDTCouchOperation completion handler, that's handled
+ by the caller of this method.
+ */
+- (void)processResponseWithData:(nullable NSData *)responseData
+                     statusCode:(NSInteger)statusCode
+                          error:(nullable NSError *)error;
+
+
+@end

--- a/ObjectiveCloudant.xcodeproj/project.pbxproj
+++ b/ObjectiveCloudant.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		275B9CD01BA9D3770023CB63 /* PutDocumentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 275B9CCF1BA9D3770023CB63 /* PutDocumentTests.m */; };
 		279E8D331B7F905B001100D4 /* ObjectiveCloudant.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 279E8D281B7F905B001100D4 /* ObjectiveCloudant.framework */; };
 		27BC070B1C0459E4009C6440 /* CDTOperationRequestBuilderDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BC070A1C04588D009C6440 /* CDTOperationRequestBuilderDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27BC070E1C07366E009C6440 /* CDTOperationRequestExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BC070C1C07366E009C6440 /* CDTOperationRequestExecutor.h */; settings = {ASSET_TAGS = (); }; };
+		27BC070F1C07366E009C6440 /* CDTOperationRequestExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 27BC070D1C07366E009C6440 /* CDTOperationRequestExecutor.m */; settings = {ASSET_TAGS = (); }; };
+		27BC07111C073717009C6440 /* CDTOperationRequestExecutorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 27BC07101C073717009C6440 /* CDTOperationRequestExecutorDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27F6B7211BA9C266000B523E /* TestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F6B71E1BA9C243000B523E /* TestHelpers.m */; };
 		27F6B7241BA9C322000B523E /* CDTCreateDatabaseOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 27F6B7221BA9C322000B523E /* CDTCreateDatabaseOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		27F6B7251BA9C322000B523E /* CDTCreateDatabaseOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F6B7231BA9C322000B523E /* CDTCreateDatabaseOperation.m */; };
@@ -101,6 +104,9 @@
 		279E8D281B7F905B001100D4 /* ObjectiveCloudant.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectiveCloudant.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		279E8D321B7F905B001100D4 /* ObjectiveCloudant.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectiveCloudant.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		27BC070A1C04588D009C6440 /* CDTOperationRequestBuilderDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CDTOperationRequestBuilderDelegate.h; path = ObjectiveCloudant/HTTP/CDTOperationRequestBuilderDelegate.h; sourceTree = SOURCE_ROOT; };
+		27BC070C1C07366E009C6440 /* CDTOperationRequestExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTOperationRequestExecutor.h; path = ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.h; sourceTree = SOURCE_ROOT; };
+		27BC070D1C07366E009C6440 /* CDTOperationRequestExecutor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTOperationRequestExecutor.m; path = ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m; sourceTree = SOURCE_ROOT; };
+		27BC07101C073717009C6440 /* CDTOperationRequestExecutorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTOperationRequestExecutorDelegate.h; sourceTree = SOURCE_ROOT; };
 		27F6B71D1BA9C243000B523E /* TestHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestHelpers.h; path = ObjectiveCloudantTests/TestHelpers.h; sourceTree = SOURCE_ROOT; };
 		27F6B71E1BA9C243000B523E /* TestHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestHelpers.m; path = ObjectiveCloudantTests/TestHelpers.m; sourceTree = SOURCE_ROOT; };
 		27F6B7221BA9C322000B523E /* CDTCreateDatabaseOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTCreateDatabaseOperation.h; path = ObjectiveCloudant/Operations/CDTCreateDatabaseOperation.h; sourceTree = SOURCE_ROOT; };
@@ -167,9 +173,9 @@
 			children = (
 				274CF66D1B9055B9008BBD50 /* CDTCouchDatabaseOperation.h */,
 				274CF66E1B9055B9008BBD50 /* CDTCouchDatabaseOperation.m */,
-				274CF6711B9055B9008BBD50 /* CDTGetDocumentOperation.h */,
 				9851D1761BC57C2700145176 /* CDTQueryFindDocumentsOperation.h */,
 				9851D1771BC57C2700145176 /* CDTQueryFindDocumentsOperation.m */,
+				274CF6711B9055B9008BBD50 /* CDTGetDocumentOperation.h */,
 				274CF6721B9055B9008BBD50 /* CDTGetDocumentOperation.m */,
 				275B9CCB1BA9D3540023CB63 /* CDTPutDocumentOperation.h */,
 				275B9CCC1BA9D3540023CB63 /* CDTPutDocumentOperation.m */,
@@ -292,6 +298,9 @@
 				273EF55D1C00B870009A09E3 /* CDTOperationRequestBuilder.h */,
 				273EF55E1C00B870009A09E3 /* CDTOperationRequestBuilder.m */,
 				27BC070A1C04588D009C6440 /* CDTOperationRequestBuilderDelegate.h */,
+				27BC07101C073717009C6440 /* CDTOperationRequestExecutorDelegate.h */,
+				27BC070C1C07366E009C6440 /* CDTOperationRequestExecutor.h */,
+				27BC070D1C07366E009C6440 /* CDTOperationRequestExecutor.m */,
 			);
 			name = HTTP;
 			sourceTree = "<group>";
@@ -315,6 +324,7 @@
 			files = (
 				274CF6791B9055B9008BBD50 /* CDTCouchDatabaseOperation.h in Headers */,
 				274CF6731B9055B9008BBD50 /* CDTCouchDBClient.h in Headers */,
+				27BC07111C073717009C6440 /* CDTOperationRequestExecutorDelegate.h in Headers */,
 				274CF67B1B9055B9008BBD50 /* CDTCouchOperation.h in Headers */,
 				273EF55F1C00B870009A09E3 /* CDTOperationRequestBuilder.h in Headers */,
 				274CF6781B9055B9008BBD50 /* ObjectiveCloudant.h in Headers */,
@@ -331,6 +341,7 @@
 				9851D1781BC57C2700145176 /* CDTQueryFindDocumentsOperation.h in Headers */,
 				274CF6751B9055B9008BBD50 /* CDTDatabase.h in Headers */,
 				98629D671BB40EF900E7F5E8 /* CDTCouchOperation+internal.h in Headers */,
+				27BC070E1C07366E009C6440 /* CDTOperationRequestExecutor.h in Headers */,
 				9851D1801BC666C000145176 /* CDTSortSyntaxValidator.h in Headers */,
 				984AA6611BB17E9E003D4DCA /* CDTCreateQueryIndexOperation.h in Headers */,
 				27F6B72A1BA9C98C000B523E /* CDTDeleteDatabaseOperation.h in Headers */,
@@ -503,6 +514,7 @@
 				273EF5601C00B870009A09E3 /* CDTOperationRequestBuilder.m in Sources */,
 				984AA65C1BAFF8C4003D4DCA /* CDTDeleteDocumentOperation.m in Sources */,
 				980B2BF81BC27CC800CD40F8 /* CDTDeleteQueryIndexOperation.m in Sources */,
+				27BC070F1C07366E009C6440 /* CDTOperationRequestExecutor.m in Sources */,
 				98629D681BB40EF900E7F5E8 /* CDTCouchOperation+internal.m in Sources */,
 				274CF6741B9055B9008BBD50 /* CDTCouchDBClient.m in Sources */,
 				274CF67A1B9055B9008BBD50 /* CDTCouchDatabaseOperation.m in Sources */,

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.h
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.h
@@ -54,4 +54,12 @@
  */
 - (void)executeRequest;
 
+/**
+ Cancel an ongoing request.
+ 
+ This will just call cancel on the underlying request, if the request completes, callbacks
+ will still be fired.
+ */
+- (void)cancel;
+
 @end

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.h
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.h
@@ -1,0 +1,57 @@
+//
+//  CDTOperationRequestExecutor.h
+//  ObjectiveCloudant
+//
+//  Created by Michael Rhodes on 21/11/2015.
+//  Copyright (c) 2015 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTOperationRequestExecutorDelegate.h"
+
+@class CDTCouchOperation;
+
+/**
+ The executor handles the boilerplate of making a request
+ and doing initial processing of the response. It calls back
+ into the operation for operation-specific items.
+ 
+ Broadly the order of operations is:
+ 
+ 1. Create a request using CDTOperationRequestBuilder and the operation.
+ 2. Execute the request asynchronously.
+ 3. On receiving the response:
+ 1. Check whether the operation is cancelled; if so, call `-completeOperation`
+ on the operation, then return early.
+ 2. Call `-processResponseWithData:statusCode:error:` on the operation.
+ 3. Call `-completeOperation` on the operation.
+ 4. Return.
+ 
+ The idea is to remove the necessity of calling completeOperation, checking for cancellation,
+ retrieving the status code and so on from the operations themselves.
+ 
+ */
+@interface CDTOperationRequestExecutor : NSObject
+
+/**
+ Initialise with the operation to make a request for.
+ */
+- (instancetype)initWithOperation:(NSOperation<CDTOperationRequestExecutorDelegate> *)operation;
+
+/**
+ Execute the request async, and callback into the operation as described above.
+ 
+ After calling executeRequest, the operation need not retain the executor.
+ */
+- (void)executeRequest;
+
+@end

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m
@@ -77,4 +77,11 @@
     [self.task resume];
 }
 
+- (void)cancel
+{
+    if (self.task) {
+        [self.task cancel];
+    }
+}
+
 @end

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m
@@ -79,8 +79,9 @@
 
 - (void)cancel
 {
-    if (self.task) {
-        [self.task cancel];
+    CDTURLSessionTask *task = self.task;
+    if (task) {
+        [task cancel];
     }
 }
 

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m
@@ -1,0 +1,80 @@
+//
+//  CDTOperationRequestExecutor.m
+//  ObjectiveCloudant
+//
+//  Created by Michael Rhodes on 21/11/2015.
+//  Copyright (c) 2015 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTOperationRequestExecutor.h"
+
+#import "CDTCouchOperation.h"
+#import "CDTOperationRequestBuilder.h"
+
+@interface CDTOperationRequestExecutor ()
+
+@property (nonatomic, strong) NSOperation<CDTOperationRequestExecutorDelegate> *operation;
+
+/** Task is retained so the executor isn't deallocated before it's completed. */
+@property (nullable, nonatomic, strong) CDTURLSessionTask *task;
+
+@end
+
+@implementation CDTOperationRequestExecutor
+
+- (instancetype)initWithOperation:(NSOperation<CDTOperationRequestExecutorDelegate> *)operation;
+{
+    self = [super init];
+    if (self) {
+        _operation = operation;
+    }
+    return self;
+}
+
+- (void)executeRequest
+{
+    CDTOperationRequestBuilder *b =
+    [[CDTOperationRequestBuilder alloc] initWithOperation:self.operation];
+    NSURLRequest *request = [b buildRequest];
+    
+    // This is a retain loop. Self retains the task which retains the copied block which
+    // retains self. We break the cycle when we set `self.task = nil` at the start of the
+    // block. The loop is used to prevent the executor being deallocated before the task
+    // is complete.
+    self.task = [self.operation.session
+                 dataTaskWithRequest:request
+                 completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable res,
+                                     NSError *_Nullable error) {
+                     
+                     // Break retain cycle (tested with breakpoint in a -dealloc for this class)
+                     self.task = nil;
+                     
+                     if (!self) {
+                         return;
+                     }
+                     
+                     if ([self.operation isCancelled]) {
+                         [self.operation completeOperation];
+                         return;
+                     }
+                     
+                     NSInteger statusCode = ((NSHTTPURLResponse *)res).statusCode;
+                     
+                     if ([self.operation respondsToSelector:@selector(processResponseWithData:statusCode:error:)]) {
+                         [self.operation processResponseWithData:data statusCode:statusCode error:error];
+                     }
+                     
+                     [self.operation completeOperation];
+                 }];
+    [self.task resume];
+}
+
+@end

--- a/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m
+++ b/ObjectiveCloudant/HTTP/CDTOperationRequestExecutor.m
@@ -21,7 +21,7 @@
 
 @interface CDTOperationRequestExecutor ()
 
-@property (nonatomic, strong) NSOperation<CDTOperationRequestExecutorDelegate> *operation;
+@property (nonatomic, weak) NSOperation<CDTOperationRequestExecutorDelegate> *operation;
 
 /** Task is retained so the executor isn't deallocated before it's completed. */
 @property (nullable, nonatomic, strong) CDTURLSessionTask *task;

--- a/ObjectiveCloudant/Operations/CDTCouchOperation+internal.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation+internal.h
@@ -24,6 +24,6 @@
 @interface CDTCouchOperation (internal)
 
 /** Executor which handles issuing the request to Couch or Cloudant. */
-@property (nullable, nonatomic, weak) CDTOperationRequestExecutor* requestExecutor;
+@property (nullable, nonatomic, strong) CDTOperationRequestExecutor* requestExecutor;
 
 @end

--- a/ObjectiveCloudant/Operations/CDTCouchOperation+internal.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation+internal.h
@@ -16,14 +16,14 @@
 #import <Foundation/Foundation.h>
 #import "CDTCouchOperation.h"
 
+@class CDTOperationRequestExecutor;
+
 /*
  Internal category to expose properties on CDTCouchOperation.
  */
 @interface CDTCouchOperation (internal)
 
-/**
- The HTTP session to use when making requests.
- */
-@property (nullable, nonatomic, strong) CDTURLSessionTask* task;
+/** Executor which handles issuing the request to Couch or Cloudant. */
+@property (nullable, nonatomic, weak) CDTOperationRequestExecutor* requestExecutor;
 
 @end

--- a/ObjectiveCloudant/Operations/CDTCouchOperation+internal.m
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation+internal.m
@@ -16,6 +16,6 @@
 
 @implementation CDTCouchOperation (internal)
 
-@dynamic task;
+@dynamic requestExecutor;
 
 @end

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 #import "CDTInterceptableSession.h"
-#import "CDTOperationRequestBuilderDelegate.h"
+#import "CDTOperationRequestExecutorDelegate.h"
 
 /**
  The CDTObjectiveCloudantErrorDomain String
@@ -75,7 +75,7 @@ typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
 
  Centralises the HTTP connections made to Cloudant.
  */
-@interface CDTCouchOperation : NSOperation <CDTOperationRequestBuilderDelegate> {
+@interface CDTCouchOperation : NSOperation <CDTOperationRequestExecutorDelegate> {
     BOOL executing;
     BOOL finished;
 }

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -18,6 +18,8 @@
 #import "CDTInterceptableSession.h"
 #import "CDTOperationRequestExecutorDelegate.h"
 
+@class CDTOperationRequestExecutor;
+
 /**
  The CDTObjectiveCloudantErrorDomain String
  */

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.m
@@ -62,8 +62,10 @@ NSInteger const kCDTNoHTTPStatus = 0;
 - (void)cancel
 {
     [super cancel];
-    if (self.requestExecutor) {
-        [self.requestExecutor cancel];
+    
+    CDTOperationRequestExecutor *requestExecutor = self.requestExecutor;
+    if (requestExecutor) {
+        [requestExecutor cancel];
     }
 }
 

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.m
@@ -23,7 +23,7 @@ NSInteger const kCDTNoHTTPStatus = 0;
 
 @interface CDTCouchOperation ()
 
-@property (nullable, nonatomic, weak) CDTOperationRequestExecutor* requestExecutor;
+@property (nullable, nonatomic, strong) CDTOperationRequestExecutor* requestExecutor;
 
 @end
 

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.m
@@ -16,6 +16,7 @@
 
 #import "CDTCouchOperation.h"
 #import "CDTCouchOperation+internal.h"
+#import "CDTOperationRequestExecutor.h"
 
 NSString *const CDTObjectiveCloudantErrorDomain = @"CDTObjectiveCloudantErrorDomain";
 NSInteger const kCDTNoHTTPStatus = 0;
@@ -91,7 +92,10 @@ NSInteger const kCDTNoHTTPStatus = 0;
 
     // If the operation is not canceled, begin executing the task.
     [self willChangeValueForKey:@"isExecuting"];
-    [self dispatchAsyncHttpRequest];
+    //    [self dispatchAsyncHttpRequest];
+    CDTOperationRequestExecutor *executor =
+    [[CDTOperationRequestExecutor alloc] initWithOperation:self];
+    [executor executeRequest];
     executing = YES;
     [self didChangeValueForKey:@"isExecuting"];
 }

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.m
@@ -23,7 +23,7 @@ NSInteger const kCDTNoHTTPStatus = 0;
 
 @interface CDTCouchOperation ()
 
-@property (nullable, nonatomic, strong) CDTURLSessionTask *task;
+@property (nullable, nonatomic, weak) CDTOperationRequestExecutor* requestExecutor;
 
 @end
 
@@ -58,10 +58,13 @@ NSInteger const kCDTNoHTTPStatus = 0;
 - (BOOL)isExecuting { return executing; }
 
 - (BOOL)isFinished { return finished; }
+
 - (void)cancel
 {
     [super cancel];
-    [self.task cancel];
+    if (self.requestExecutor) {
+        [self.requestExecutor cancel];
+    }
 }
 
 - (void)start
@@ -95,6 +98,7 @@ NSInteger const kCDTNoHTTPStatus = 0;
     CDTOperationRequestExecutor *executor =
     [[CDTOperationRequestExecutor alloc] initWithOperation:self];
     [executor executeRequest];
+    self.requestExecutor = executor;
     executing = YES;
     [self didChangeValueForKey:@"isExecuting"];
 }

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.m
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.m
@@ -92,7 +92,6 @@ NSInteger const kCDTNoHTTPStatus = 0;
 
     // If the operation is not canceled, begin executing the task.
     [self willChangeValueForKey:@"isExecuting"];
-    //    [self dispatchAsyncHttpRequest];
     CDTOperationRequestExecutor *executor =
     [[CDTOperationRequestExecutor alloc] initWithOperation:self];
     [executor executeRequest];


### PR DESCRIPTION
# What

Move request boilerplate to CDTOperationRequestExecutor

# Why

Most of the process of making a request is the same in all operations:
create the request object, create a task, wait for the task, check
cancelled, do some special processing and the complete the operation.

The only part that is specific to each operation is the "do some special
processing" part.

This commit pulls all the other surrounding code into an executor class
whose job is to take an NSOperation implementing
CDTOperationRequestExecutorDelegate and make the request using the
values returned from the delegate instance, handling all the
NSOperation and URL session stuff.

# Reviewers

reviewer @rhyshort