### PR TITLE
Add support for Querying Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [NEW] CDTQueryViewOperation API to Query Map Reduce Views.
+
 # 0.2.2 (2015-11-24)
 
 - [FIX] Fixed issue where `selector` wasn't put into the POST body for text index

--- a/ObjectiveCloudant.xcodeproj/project.pbxproj
+++ b/ObjectiveCloudant.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		9896FE801BB57DAD00856BD7 /* CreateIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9896FE7F1BB57DAD00856BD7 /* CreateIndexTests.m */; };
 		98A87EE21C6E31DA00D8B0E1 /* CDTOperationRequestBuilderDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A87EE01C6E31DA00D8B0E1 /* CDTOperationRequestBuilderDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		98A87EE31C6E31DA00D8B0E1 /* CDTOperationRequestExecutorDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A87EE11C6E31DA00D8B0E1 /* CDTOperationRequestExecutorDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98A87EEA1C71E4A600D8B0E1 /* CDTQueryViewOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 98A87EE81C71E4A600D8B0E1 /* CDTQueryViewOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		98A87EEB1C71E4A600D8B0E1 /* CDTQueryViewOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 98A87EE91C71E4A600D8B0E1 /* CDTQueryViewOperation.m */; };
+		98ABDD191C7484BD00D6FE32 /* QueryViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98ABDD171C74846E00D6FE32 /* QueryViewTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -144,6 +147,9 @@
 		9896FE7F1BB57DAD00856BD7 /* CreateIndexTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CreateIndexTests.m; path = ObjectiveCloudantTests/CreateIndexTests.m; sourceTree = SOURCE_ROOT; };
 		98A87EE01C6E31DA00D8B0E1 /* CDTOperationRequestBuilderDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTOperationRequestBuilderDelegate.h; path = ObjectiveCloudant/HTTP/CDTOperationRequestBuilderDelegate.h; sourceTree = SOURCE_ROOT; };
 		98A87EE11C6E31DA00D8B0E1 /* CDTOperationRequestExecutorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CDTOperationRequestExecutorDelegate.h; path = ObjectiveCloudant/HTTP/CDTOperationRequestExecutorDelegate.h; sourceTree = SOURCE_ROOT; };
+		98A87EE81C71E4A600D8B0E1 /* CDTQueryViewOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQueryViewOperation.h; sourceTree = "<group>"; };
+		98A87EE91C71E4A600D8B0E1 /* CDTQueryViewOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQueryViewOperation.m; sourceTree = "<group>"; };
+		98ABDD171C74846E00D6FE32 /* QueryViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = QueryViewTests.m; path = ObjectiveCloudantTests/QueryViewTests.m; sourceTree = SOURCE_ROOT; };
 		9BE38C8FC08AD2F7D5DE29A0 /* Pods-ObjectiveCloudantTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectiveCloudantTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectiveCloudantTests/Pods-ObjectiveCloudantTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EF088291BC169B0422274EC2 /* Pods_ObjectiveCloudantTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ObjectiveCloudantTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -179,6 +185,8 @@
 		274CF66C1B9055B9008BBD50 /* Operations - Database */ = {
 			isa = PBXGroup;
 			children = (
+				98A87EE81C71E4A600D8B0E1 /* CDTQueryViewOperation.h */,
+				98A87EE91C71E4A600D8B0E1 /* CDTQueryViewOperation.m */,
 				274CF66D1B9055B9008BBD50 /* CDTCouchDatabaseOperation.h */,
 				274CF66E1B9055B9008BBD50 /* CDTCouchDatabaseOperation.m */,
 				9851D1761BC57C2700145176 /* CDTQueryFindDocumentsOperation.h */,
@@ -240,6 +248,7 @@
 		279E8D361B7F905B001100D4 /* ObjectiveCloudantTests */ = {
 			isa = PBXGroup;
 			children = (
+				98ABDD171C74846E00D6FE32 /* QueryViewTests.m */,
 				984AA6581BAC5CA7003D4DCA /* HTTP */,
 				274CF6831B9055F6008BBD50 /* Info.plist */,
 				27F6B7261BA9C7A4000B523E /* CreateDatabaseTests.m */,
@@ -340,6 +349,7 @@
 				9851D1781BC57C2700145176 /* CDTQueryFindDocumentsOperation.h in Headers */,
 				274CF6751B9055B9008BBD50 /* CDTDatabase.h in Headers */,
 				98629D671BB40EF900E7F5E8 /* CDTCouchOperation+internal.h in Headers */,
+				98A87EEA1C71E4A600D8B0E1 /* CDTQueryViewOperation.h in Headers */,
 				273EF55F1C00B870009A09E3 /* CDTOperationRequestBuilder.h in Headers */,
 				27BC070E1C07366E009C6440 /* CDTOperationRequestExecutor.h in Headers */,
 				9851D1801BC666C000145176 /* CDTSortSyntaxValidator.h in Headers */,
@@ -507,6 +517,7 @@
 				9851D1811BC666C000145176 /* CDTSortSyntaxValidator.m in Sources */,
 				274CF67E1B9055B9008BBD50 /* CDTGetDocumentOperation.m in Sources */,
 				984AA6351BAAFA08003D4DCA /* CDTHTTPInterceptorContext.m in Sources */,
+				98A87EEB1C71E4A600D8B0E1 /* CDTQueryViewOperation.m in Sources */,
 				984AA6381BAAFA08003D4DCA /* CDTSessionCookieInterceptor.m in Sources */,
 				27F6B7251BA9C322000B523E /* CDTCreateDatabaseOperation.m in Sources */,
 				27F6B72B1BA9C98C000B523E /* CDTDeleteDatabaseOperation.m in Sources */,
@@ -534,6 +545,7 @@
 				984AA6571BAC5CA0003D4DCA /* CDTURLSessionTests.m in Sources */,
 				9851D1831BC67A6400145176 /* FindDocumentTests.m in Sources */,
 				275B9CD01BA9D3770023CB63 /* PutDocumentTests.m in Sources */,
+				98ABDD191C7484BD00D6FE32 /* QueryViewTests.m in Sources */,
 				9896FE801BB57DAD00856BD7 /* CreateIndexTests.m in Sources */,
 				984AA6561BAC5CA0003D4DCA /* CDTURLSessionTaskTests.m in Sources */,
 				988D313C1BBE9B4400EFB290 /* CouchDBTests.m in Sources */,

--- a/ObjectiveCloudant/ObjectiveCloudant.h
+++ b/ObjectiveCloudant/ObjectiveCloudant.h
@@ -57,3 +57,4 @@ typedef NS_ENUM(NSUInteger, CDTQueryIndexType) {
 #import <ObjectiveCloudant/CDTCreateQueryIndexOperation.h>
 #import <ObjectiveCloudant/CDTDeleteQueryIndexOperation.h>
 #import <ObjectiveCloudant/CDTQueryFindDocumentsOperation.h>
+#import <ObjectiveCloudant/CDTQueryViewOperation.h>

--- a/ObjectiveCloudant/Operations/CDTCouchOperation.h
+++ b/ObjectiveCloudant/Operations/CDTCouchOperation.h
@@ -34,42 +34,47 @@ extern NSInteger const kCDTNoHTTPStatus;
  * Replication errors.
  */
 typedef NS_ENUM(NSInteger, CDTObjectiveCloudantErrors) {
-/**
- Creating a database failed.
- */
+    /**
+     Creating a database failed.
+     */
     CDTObjectiveCloudantErrorCreateDatabaseFailed,
-/**
- Deleting a database failed.
- */
+    /**
+     Deleting a database failed.
+     */
     CDTObjectiveCloudantErrorDeleteDatabaseFailed,
-/**
- Validation of operation settings failed.
-*/
+    /**
+     Validation of operation settings failed.
+    */
     CDTObjectiveCloudantErrorValidationFailed,
-/**
- Deleting a Query index failed.
- */
+    /**
+     Deleting a Query index failed.
+     */
     CDTObjectiveCloudantErrorDeleteQueryIndexFailed,
-/**
- Creating a Query index failed.
- */
+    /**
+     Creating a Query index failed.
+     */
     CDTObjectiveCloudantErrorCreateQueryIndexFailed,
-/**
- Getting a document failed.
- */
+    /**
+     Getting a document failed.
+     */
     CDTObjectiveCloudantErrorGetDocumentFailed,
-/**
- Creating or updating a document failed.
- */
+    /**
+     Creating or updating a document failed.
+     */
     CDTObjectiveCloudantErrorCreateUpdateDocumentFailed,
-/**
- Deleting a document failed.
- */
+    /**
+     Deleting a document failed.
+     */
     CDTObjectiveCloudantErrorDeleteDocumentFailed,
-/**
- Finding documents failed.
- */
-    CDTObjectiveCloudantErrorFindDocumentsFailed
+    /**
+     Finding documents failed.
+     */
+    CDTObjectiveCloudantErrorFindDocumentsFailed,
+
+    /**
+     Querying a view failed.
+     */
+    CDTObjectiveCloudantErrorQueryViewFailed
 };
 
 /**

--- a/ObjectiveCloudant/Operations/CDTQueryViewOperation.h
+++ b/ObjectiveCloudant/Operations/CDTQueryViewOperation.h
@@ -1,0 +1,191 @@
+//
+//  CDTGetViewOperation.h
+//  ObjectiveCloudant
+//
+//  Created by Rhys Short on 15/02/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <ObjectiveCloudant/ObjectiveCloudant.h>
+
+typedef NS_ENUM(NSUInteger, CDTStale) {
+    /**
+     Do not allow stale views.
+     **/
+    CDTStaleViewNo,
+    /**
+     Allow stale views.
+     **/
+    CDTStaleViewOk,
+    /**
+     Allow stale views, but update them immediately after the request.
+     **/
+    CDTStaleViewUpdateAfter
+};
+
+/**
+ An operation to query Map Reduce views.
+ */
+@interface CDTQueryViewOperation : CDTCouchDatabaseOperation
+
+/**
+ * The name of the design document which contains the view.
+ *
+ * Required: This needs to be set before an operation can successfully run.
+ */
+@property (nullable, nonatomic, strong) NSString *ddoc;
+
+/**
+ * The name of the view to query.
+ *
+ * Required: This needs to be set before an operation can succesfully run.
+ */
+@property (nullable, nonatomic, strong) NSString *viewName;
+
+/**
+ * Return the documents in 'descending by key' order.
+ *
+ * Default : NO, order is aescending by key.
+ */
+@property (nonatomic) BOOL descending;
+
+/**
+ * Stop the view returning results when the specified key is reached.
+ * It must be set to an Object of type `NSString*` or `NSArray<NSString*>*`.
+ *
+ * Optional: CouchDB will return all the results if this is not set.
+ */
+@property (nullable, nonatomic, strong) NSObject *endKey;
+
+/**
+ * Stop the view returning results when the specified document ID is reached.
+ *
+ * Optional: CouchDB will return all the results if this is not set.
+ */
+@property (nullable, nonatomic, strong) NSString *endkeyDocId;
+
+/**
+ * Group the results of a reduced based on their keys.
+ *
+ * Default: NO.
+ */
+@property (nonatomic) BOOL group;
+
+/**
+ * Group reduce results for documents with complex keys. Using the first x number of items in the
+ * complex key array, where x is the group level.
+ *
+ * For example, if you had the complex key : ["A","B", "C", "D"], if groupLevel is set to 3,
+ * "A", "B" and "C" would be used to group the view results.
+ *
+ * Optional: CouchDB will use the default groupLevel if grouping is enabled, negative values will
+ * result in the parameter not being included in requests
+ **/
+@property (nonatomic) NSInteger groupLevel;
+
+/**
+ * Include the full document content in the view results.
+ *
+ * Default: NO
+ */
+@property (nonatomic) BOOL includeDocs;
+
+/**
+ * Include rows with the specified `endKey`.
+ *
+ * Default: NO.
+ */
+@property (nonatomic) BOOL inclusiveEnd;
+
+/**
+ * Return only documents that match the specified key.
+ * The key must be of type `NSString*` or `NSArray<NSString*>*`
+ *
+ * Cannot be used with `key` option.
+ *
+ * Optional: CouchDB will return all documents emitted from the view.
+ */
+@property (nullable, nonatomic, strong) NSObject *key;
+
+/**
+ * Return only the documents that match the specified keys.
+ * The keys in the array must be of type `NSString*` or `NSArray<NSString*>*`
+ *
+ * Optional: CouchDB will return all documents emitted from the view.
+ */
+@property (nullable, nonatomic, strong) NSArray<NSObject *> *keys;
+
+/**
+ * Limit the number of documents returned from the view.
+ *
+ * Optional: CouchDB will return all documents emitted from the view, negative values will
+ * result in the parameter not being included in requests.
+ */
+@property (nonatomic) NSInteger limit;
+
+/**
+ * Use the reduce function for the view.
+ *
+ * Default: NO.
+ */
+@property (nonatomic) BOOL reduce;
+
+/**
+ * The number of rows to skip in the view results.
+ *
+ * Optional, CouchDB will noy skip any matching rows, negative values will
+ * result in the parameter not being included in requests
+ */
+@property (nonatomic) NSInteger skip;
+
+/**
+ * Allows a stale view to be used to return a result, this allows the request
+ * to return imediately and not wait for views to build.
+ *
+ * Default: CDTStaleViewNo.
+ *
+ * WANRING: This is an advanced option, it should not be used unless you know exactly what you are
+ * doing, it will be deterimental to performance.
+ */
+@property (nonatomic) CDTStale stale;
+
+/**
+ * Return records starting with the specified key.
+ * The key must be of type `NSString*` or `NSArray<NSString*>*`.
+ *
+ * Optional: CouchDB will return all records emitted from the view.
+ *
+ */
+@property (nullable, nonatomic, strong) NSObject *startKey;
+
+/**
+ * Return records starting with the specified document ID.
+ *
+ * Optional: CouchDB will return all records emitted from the view.
+ */
+@property (nullable, nonatomic, strong) NSString *startKeyDocId;
+
+/**
+ * Block to run for each row in response to the view query.
+ *
+ * - row - a row in the response to the view query.
+ **/
+@property (nullable, nonatomic, strong) void (^viewRowBlock)
+    (NSDictionary<NSString *, NSObject *> *_Nonnull row);
+
+/**
+ *  Completion blokc to run when the operation completes.
+ *
+ * - error a pointer to an error object containing information about an error executing the
+ * operation.
+ */
+@property (nullable, nonatomic, strong) void (^queryViewCompletionBlock)(NSError *_Nullable error);
+@end

--- a/ObjectiveCloudant/Operations/CDTQueryViewOperation.h
+++ b/ObjectiveCloudant/Operations/CDTQueryViewOperation.h
@@ -1,5 +1,5 @@
 //
-//  CDTGetViewOperation.h
+//  CDTQueryViewOperation.h
 //  ObjectiveCloudant
 //
 //  Created by Rhys Short on 15/02/2016.
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSUInteger, CDTStale) {
 /**
  * Return the documents in 'descending by key' order.
  *
- * Default : NO, order is aescending by key.
+ * Default : NO, order is ascending by key.
  */
 @property (nonatomic) BOOL descending;
 
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSUInteger, CDTStale) {
 @property (nullable, nonatomic, strong) NSString *endkeyDocId;
 
 /**
- * Group the results of a reduced based on their keys.
+ * Group the results of a reduce based on their keys.
  *
  * Default: NO.
  */
@@ -109,7 +109,7 @@ typedef NS_ENUM(NSUInteger, CDTStale) {
  * Return only documents that match the specified key.
  * The key must be of type `NSString*` or `NSArray<NSString*>*`
  *
- * Cannot be used with `key` option.
+ * Cannot be used with `keys` option.
  *
  * Optional: CouchDB will return all documents emitted from the view.
  */
@@ -118,6 +118,8 @@ typedef NS_ENUM(NSUInteger, CDTStale) {
 /**
  * Return only the documents that match the specified keys.
  * The keys in the array must be of type `NSString*` or `NSArray<NSString*>*`
+ *
+ * Cannot be used with `key` option.
  *
  * Optional: CouchDB will return all documents emitted from the view.
  */
@@ -141,19 +143,19 @@ typedef NS_ENUM(NSUInteger, CDTStale) {
 /**
  * The number of rows to skip in the view results.
  *
- * Optional, CouchDB will noy skip any matching rows, negative values will
+ * Optional, CouchDB will not skip any matching rows, negative values will
  * result in the parameter not being included in requests
  */
 @property (nonatomic) NSInteger skip;
 
 /**
  * Allows a stale view to be used to return a result, this allows the request
- * to return imediately and not wait for views to build.
+ * to return immediately and not wait for views to build.
  *
  * Default: CDTStaleViewNo.
  *
  * WANRING: This is an advanced option, it should not be used unless you know exactly what you are
- * doing, it will be deterimental to performance.
+ * doing, it will be detrimental to performance.
  */
 @property (nonatomic) CDTStale stale;
 
@@ -182,7 +184,7 @@ typedef NS_ENUM(NSUInteger, CDTStale) {
     (NSDictionary<NSString *, NSObject *> *_Nonnull row);
 
 /**
- *  Completion blokc to run when the operation completes.
+ *  Completion block to run when the operation completes.
  *
  * - error a pointer to an error object containing information about an error executing the
  * operation.

--- a/ObjectiveCloudant/Operations/CDTQueryViewOperation.m
+++ b/ObjectiveCloudant/Operations/CDTQueryViewOperation.m
@@ -1,0 +1,291 @@
+//
+//  CDTGetViewOperation.m
+//  ObjectiveCloudant
+//
+//  Created by Rhys Short on 15/02/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+#import "CDTQueryViewOperation.h"
+
+static const int kCDTDefaultOperationIntegerValue = -1;
+
+@implementation CDTQueryViewOperation
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _descending = NO;
+        _group = NO;
+        _groupLevel = kCDTDefaultOperationIntegerValue;
+        _includeDocs = NO;
+        _inclusiveEnd = NO;
+        _limit = kCDTDefaultOperationIntegerValue;
+        _skip = kCDTDefaultOperationIntegerValue;
+        _stale = CDTStaleViewNo;
+    }
+    return self;
+}
+
+- (BOOL)buildAndValidate
+{
+    if (![super buildAndValidate]) {
+        return NO;
+    }
+
+    if (!self.ddoc) {
+        return NO;
+    }
+
+    if (!self.viewName) {
+        return NO;
+    }
+
+    // Query params
+
+    if (self.endKey && ![CDTQueryViewOperation isValidStringOrJsonArray:self.endKey]) {
+        return NO;
+    }
+
+    if (self.endkeyDocId && ![CDTQueryViewOperation isValidStringOrJsonArray:self.endkeyDocId]) {
+        return NO;
+    }
+
+    if (self.key && self.keys) {
+        return NO;
+    }
+
+    if (self.key && ![CDTQueryViewOperation isValidStringOrJsonArray:self.key]) {
+        return NO;
+    }
+
+    if (self.keys && ![CDTQueryViewOperation isValidStringOrJsonArray:self.keys]) {
+        return NO;
+    }
+
+    if (self.startKey && ![CDTQueryViewOperation isValidStringOrJsonArray:self.startKey]) {
+        return NO;
+    }
+
+    if (self.startKeyDocId &&
+        ![CDTQueryViewOperation isValidStringOrJsonArray:self.startKeyDocId]) {
+        return NO;
+    }
+
+    return YES;
+}
+
+- (NSString *)httpMethod { return @"GET"; }
+- (NSString *)httpPath
+{
+    return [NSString
+        stringWithFormat:@"/%@/_design/%@/_view/%@", self.databaseName, self.ddoc, self.viewName];
+}
+
+- (nonnull NSArray<NSURLQueryItem *> *)queryItems
+{
+    NSMutableArray<NSURLQueryItem *> *queryItems = [NSMutableArray array];
+
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:@"descending"
+                                                      value:[CDTQueryViewOperation
+                                                                stringForBoolean:self.descending]]];
+    if (self.endKey) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"endkey"
+                                                          value:[CDTQueryViewOperation
+                                                                    stringForObject:self.endKey]]];
+    }
+
+    if (self.endkeyDocId) {
+        [queryItems
+            addObject:[NSURLQueryItem queryItemWithName:@"endkey_docid" value:self.endkeyDocId]];
+    }
+
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:@"group"
+                                                      value:[CDTQueryViewOperation
+                                                                stringForBoolean:self.group]]];
+
+    if (self.groupLevel != kCDTDefaultOperationIntegerValue) {
+        [queryItems
+            addObject:[NSURLQueryItem
+                          queryItemWithName:@"group_level"
+                                      value:[NSString
+                                                stringWithFormat:@"%ld", (long)self.groupLevel]]];
+    }
+
+    [queryItems
+        addObject:[NSURLQueryItem
+                      queryItemWithName:@"include_docs"
+                                  value:[CDTQueryViewOperation stringForBoolean:self.includeDocs]]];
+
+    [queryItems
+        addObject:[NSURLQueryItem queryItemWithName:@"inclusive_end"
+                                              value:[CDTQueryViewOperation
+                                                        stringForBoolean:self.inclusiveEnd]]];
+
+    if (self.key) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"key"
+                                                          value:[CDTQueryViewOperation
+                                                                    stringForObject:self.key]]];
+    }
+
+    if (self.keys) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"keys"
+                                                          value:[CDTQueryViewOperation
+                                                                    stringForObject:self.keys]]];
+    }
+
+    if (self.limit != kCDTDefaultOperationIntegerValue) {
+        [queryItems
+            addObject:[NSURLQueryItem
+                          queryItemWithName:@"limit"
+                                      value:[NSString stringWithFormat:@"%ld", (long)self.limit]]];
+    }
+
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:@"reduce"
+                                                      value:[CDTQueryViewOperation
+                                                                stringForBoolean:self.reduce]]];
+
+    if (self.skip != kCDTDefaultOperationIntegerValue) {
+        [queryItems
+            addObject:[NSURLQueryItem
+                          queryItemWithName:@"skip"
+                                      value:[NSString stringWithFormat:@"%ld", (long)self.skip]]];
+    }
+
+    NSURLQueryItem *stale = [CDTQueryViewOperation QueryItemForStaleState:self.stale];
+
+    if (stale) {
+        [queryItems addObject:stale];
+    }
+
+    if (self.startKey) {
+        [queryItems
+            addObject:[NSURLQueryItem
+                          queryItemWithName:@"startkey"
+                                      value:[CDTQueryViewOperation stringForObject:self.startKey]]];
+    }
+
+    if (self.startKeyDocId) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:@"startkey_docid"
+                                                          value:self.startKeyDocId]];
+    }
+
+    return [queryItems copy];
+}
+
+- (void)callCompletionHandlerWithError:(NSError *)error
+{
+    if (self && self.queryViewCompletionBlock) {
+        self.queryViewCompletionBlock(error);
+    }
+}
+
+- (void)processResponseWithData:(NSData *)responseData
+                     statusCode:(NSInteger)statusCode
+                          error:(NSError *)error
+{
+    if (error) {
+        self.queryViewCompletionBlock(error);
+    } else if (statusCode / 100 == 2) {
+        // process the things!
+        NSError *jsonError;
+        NSDictionary<NSString *, NSObject *> *responseJson =
+            [NSJSONSerialization JSONObjectWithData:responseData options:0 error:&jsonError];
+
+        if (!responseJson) {
+            self.queryViewCompletionBlock(jsonError);
+        } else {
+            if (self.viewRowBlock) {
+                for (NSDictionary<NSString *, NSObject *> *row in(
+                         NSArray<NSDictionary<NSString *, NSObject *> *> *)responseJson[@"rows"]) {
+                    self.viewRowBlock(row);
+                }
+            }
+            if (self.queryViewCompletionBlock) {
+                self.queryViewCompletionBlock(nil);
+            }
+        }
+
+    } else {
+        NSString *json = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
+        NSString *msg = [NSString
+            stringWithFormat:@"Querying view failed with %ld %@.", (long)statusCode, json];
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey : NSLocalizedString(msg, nil)};
+        error = [NSError errorWithDomain:CDTObjectiveCloudantErrorDomain
+                                    code:CDTObjectiveCloudantErrorCreateDatabaseFailed
+                                userInfo:userInfo];
+        self.queryViewCompletionBlock(error);
+    }
+}
+
++ (BOOL)isValidStringOrJsonArray:(NSObject *)obj
+{
+    if ([obj isKindOfClass:[NSArray class]]) {
+        if (![NSJSONSerialization isValidJSONObject:obj]) {
+            return NO;
+        }
+    } else if (![obj isKindOfClass:[NSString class]]) {
+        return NO;
+    }
+
+    return YES;
+}
+
++ (NSString *)stringForBoolean:(BOOL)boolean
+{
+    if (boolean) {
+        return @"true";
+    } else {
+        return @"false";
+    }
+}
+
++ (NSString *)stringForObject:(NSObject *)obj
+{
+    if ([obj isKindOfClass:[NSArray class]]) {
+        NSError *error;
+        NSData *data = [NSJSONSerialization dataWithJSONObject:obj options:0 error:&error];
+
+        if (error) {
+            // well we need to error here
+            @throw error;
+        }
+
+        return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+
+    } else if ([obj isKindOfClass:[NSString class]]) {
+        return [NSString stringWithFormat:@"\"%@\"", (NSString *)obj];
+    } else {
+        return [NSString stringWithFormat:@"\"%@\"", [obj description]];
+    }
+}
+
++ (NSURLQueryItem *)QueryItemForStaleState:(CDTStale)stale
+{
+    NSString *staleStr;
+
+    switch (stale) {
+        case CDTStaleViewNo:
+            return nil;
+            break;
+        case CDTStaleViewOk:
+            staleStr = @"ok";
+            break;
+
+        case CDTStaleViewUpdateAfter:
+            staleStr = @"updateafter";
+            break;
+    }
+
+    return [NSURLQueryItem queryItemWithName:@"stale" value:staleStr];
+}
+
+@end

--- a/ObjectiveCloudant/Operations/CDTQueryViewOperation.m
+++ b/ObjectiveCloudant/Operations/CDTQueryViewOperation.m
@@ -1,5 +1,5 @@
 //
-//  CDTGetViewOperation.m
+//  CDTQueryViewOperation.m
 //  ObjectiveCloudant
 //
 //  Created by Rhys Short on 15/02/2016.
@@ -28,6 +28,7 @@ static const int kCDTDefaultOperationIntegerValue = -1;
         _groupLevel = kCDTDefaultOperationIntegerValue;
         _includeDocs = NO;
         _inclusiveEnd = NO;
+        _reduce = NO;
         _limit = kCDTDefaultOperationIntegerValue;
         _skip = kCDTDefaultOperationIntegerValue;
         _stale = CDTStaleViewNo;
@@ -193,7 +194,7 @@ static const int kCDTDefaultOperationIntegerValue = -1;
                           error:(NSError *)error
 {
     if (error) {
-        self.queryViewCompletionBlock(error);
+        [self callCompletionHandlerWithError:error];
     } else if (statusCode / 100 == 2) {
         // process the things!
         NSError *jsonError;
@@ -201,7 +202,7 @@ static const int kCDTDefaultOperationIntegerValue = -1;
             [NSJSONSerialization JSONObjectWithData:responseData options:0 error:&jsonError];
 
         if (!responseJson) {
-            self.queryViewCompletionBlock(jsonError);
+            [self callCompletionHandlerWithError:jsonError];
         } else {
             if (self.viewRowBlock) {
                 for (NSDictionary<NSString *, NSObject *> *row in(
@@ -220,9 +221,10 @@ static const int kCDTDefaultOperationIntegerValue = -1;
             stringWithFormat:@"Querying view failed with %ld %@.", (long)statusCode, json];
         NSDictionary *userInfo = @{NSLocalizedDescriptionKey : NSLocalizedString(msg, nil)};
         error = [NSError errorWithDomain:CDTObjectiveCloudantErrorDomain
-                                    code:CDTObjectiveCloudantErrorCreateDatabaseFailed
+                                    code:CDTObjectiveCloudantErrorQueryViewFailed
                                 userInfo:userInfo];
-        self.queryViewCompletionBlock(error);
+
+        [self callCompletionHandlerWithError:error];
     }
 }
 

--- a/ObjectiveCloudant/Operations/CDTQueryViewOperation.m
+++ b/ObjectiveCloudant/Operations/CDTQueryViewOperation.m
@@ -258,7 +258,9 @@ static const int kCDTDefaultOperationIntegerValue = -1;
 
         if (error) {
             // well we need to error here
-            @throw error;
+            @throw [NSException exceptionWithName:@"JSONSerialisationError"
+                                           reason:@"Could not seralise array into json"
+                                         userInfo:nil];
         }
 
         return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];

--- a/ObjectiveCloudantTests/QueryViewTests.m
+++ b/ObjectiveCloudantTests/QueryViewTests.m
@@ -139,6 +139,7 @@
       XCTAssertNotNil(doc[@"id"]);
       XCTAssertNotNil(doc[@"key"]);
       XCTAssertNotNil(doc[@"value"]);
+      XCTAssertNil(doc[@"doc"]);
     };
 
     op.queryViewCompletionBlock = ^(NSError *error) {
@@ -343,6 +344,7 @@
       XCTAssertEqualObjects(@"snipe", doc[@"id"]);
       XCTAssertEqualObjects(@"omnivore", doc[@"key"]);
       XCTAssertEqualObjects(@1, doc[@"value"]);
+      XCTAssertNil(doc[@"doc"]);
 
     };
 

--- a/ObjectiveCloudantTests/QueryViewTests.m
+++ b/ObjectiveCloudantTests/QueryViewTests.m
@@ -174,6 +174,9 @@
       XCTAssertNotNil(doc[@"id"]);
       XCTAssertNotNil(doc[@"key"]);
       XCTAssertNotNil(doc[@"value"]);
+      XCTAssertEqualObjects(@"kookaburra", doc[@"id"]);
+      XCTAssertEqualObjects(@"carnivore", doc[@"key"]);
+      XCTAssertEqualObjects(@1, doc[@"value"]);
     };
 
     op.queryViewCompletionBlock = ^(NSError *error) {
@@ -337,6 +340,9 @@
       XCTAssertNotNil(doc[@"id"]);
       XCTAssertNotNil(doc[@"key"]);
       XCTAssertNotNil(doc[@"value"]);
+      XCTAssertEqualObjects(@"snipe", doc[@"id"]);
+      XCTAssertEqualObjects(@"omnivore", doc[@"key"]);
+      XCTAssertEqualObjects(@1, doc[@"value"]);
 
     };
 

--- a/ObjectiveCloudantTests/QueryViewTests.m
+++ b/ObjectiveCloudantTests/QueryViewTests.m
@@ -83,8 +83,6 @@
 
     CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
     op.viewName = @"diet";
-    op.key = @"key";
-    op.keys = @[ @"keys" ];
 
     op.queryViewCompletionBlock = ^(NSError *error) {
       [completionFailed fulfill];
@@ -106,8 +104,6 @@
     CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
     op.ddoc = @"views101";
     op.viewName = @"diet";
-    op.key = @"key";
-    op.keys = @[ @"keys" ];
 
     op.queryViewCompletionBlock = ^(NSError *error) {
       [completionFailed fulfill];
@@ -122,7 +118,7 @@
                                  }];
 }
 
-- (void)testCorrectlyQueryViewNoOptions
+- (void)testSuccessfullyQueryViewNoOptions
 {
     XCTestExpectation *requestCompleted =
         [self expectationWithDescription:@"Succesfully view query"];
@@ -161,7 +157,7 @@
     XCTAssertEqual(10, numberOfDocs);
 }
 
-- (void)testCorrectlyQueryViewLimit1
+- (void)testSuccessfullyQueryViewLimit1
 {
     XCTestExpectation *requestCompleted =
         [self expectationWithDescription:@"Succesfully view query"];
@@ -193,7 +189,7 @@
                                  }];
 }
 
-- (void)testCorrectlyQueryViewDescending
+- (void)testSuccessfullyQueryViewDescending
 {
     NSArray *expectedOrderOfKeys = @[
         @"omnivore",
@@ -273,7 +269,7 @@
                                  }];
 }
 
-- (void)testCorrectlyQueryViewInculdingDocs
+- (void)testSuccessfullyQueryViewInculdingDocs
 {
     XCTestExpectation *requestCompleted =
         [self expectationWithDescription:@"Succesfully view query"];
@@ -317,7 +313,7 @@
     XCTAssertEqual(10, numberOfDocs);
 }
 
-- (void)testCorrectlyQueryViewSkipDocs
+- (void)testSuccessfullyQueryViewSkipDocs
 {
     XCTestExpectation *requestCompleted =
         [self expectationWithDescription:@"Succesfully view query"];
@@ -359,7 +355,7 @@
     XCTAssertEqual(1, numberOfDocs);
 }
 
-- (void)testCorrectlyPages
+- (void)testSuccessfullyPages
 {
     XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
     XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];

--- a/ObjectiveCloudantTests/QueryViewTests.m
+++ b/ObjectiveCloudantTests/QueryViewTests.m
@@ -1,0 +1,966 @@
+//
+//  QueryViewTests.m
+//  ObjectiveCloudant
+//
+//  Created by Rhys Short on 15/02/2016.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+#import <ObjectiveCloudant/ObjectiveCloudant.h>
+#import "TestHelpers.h"
+
+@interface QueryViewTests : XCTestCase
+@property (nonatomic, strong) NSString *url;
+@property (nonatomic, strong) NSString *dbName;
+@property (nonatomic, strong) NSString *username;
+@property (nonatomic, strong) NSString *password;
+@property (nonatomic, strong) CDTDatabase *database;
+@end
+
+@implementation QueryViewTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.url = @"http://localhost:5984";
+    self.username = nil;
+    self.password = nil;
+
+    // These tests require their own database as they modify content; create one
+
+    self.dbName = @"objectivecouch-test";
+
+    CDTCouchDBClient *client = [CDTCouchDBClient clientForURL:[NSURL URLWithString:self.url]
+                                                     username:self.username
+                                                     password:self.password];
+    self.database = client[self.dbName];
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    [super tearDown];
+}
+
+- (void)testfailsWithKeyandKeysSet
+{
+    XCTestExpectation *completionFailed =
+        [self expectationWithDescription:@"Keys and Key property set"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.key = @"key";
+    op.keys = @[ @"keys" ];
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [completionFailed fulfill];
+      XCTAssertNotNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testfailsMissingDdoc
+{
+    XCTestExpectation *completionFailed = [self expectationWithDescription:@"missing ddoc"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.viewName = @"diet";
+    op.key = @"key";
+    op.keys = @[ @"keys" ];
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [completionFailed fulfill];
+      XCTAssertNotNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testfailsMissingViewNAME
+{
+    XCTestExpectation *completionFailed = [self expectationWithDescription:@"Missing view name"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.key = @"key";
+    op.keys = @[ @"keys" ];
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [completionFailed fulfill];
+      XCTAssertNotNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testCorrectlyQueryViewNoOptions
+{
+    XCTestExpectation *requestCompleted =
+        [self expectationWithDescription:@"Succesfully view query"];
+    XCTestExpectation *viewRowBlockCalled = [self expectationWithDescription:@"Document Found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlockCalled fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(10, numberOfDocs);
+}
+
+- (void)testCorrectlyQueryViewLimit1
+{
+    XCTestExpectation *requestCompleted =
+        [self expectationWithDescription:@"Succesfully view query"];
+    XCTestExpectation *viewRowBlockCalled = [self expectationWithDescription:@"Document Found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.limit = 1;
+
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      [viewRowBlockCalled fulfill];
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testCorrectlyQueryViewDescending
+{
+    NSArray *expectedOrderOfKeys = @[
+        @"omnivore",
+        @"omnivore",
+        @"omnivore",
+        @"omnivore",
+        @"herbivore",
+        @"herbivore",
+        @"herbivore",
+        @"herbivore",
+        @"carnivore",
+        @"carnivore",
+    ];
+
+    XCTestExpectation *requestCompleted =
+        [self expectationWithDescription:@"Succesfully view query"];
+    XCTestExpectation *viewRowBlockCalled = [self expectationWithDescription:@"Document Found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.descending = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    NSMutableArray<NSString *> *orderedKeys = [NSMutableArray array];
+
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlockCalled fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+
+      [orderedKeys addObject:doc[@"key"]];
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(10, numberOfDocs);
+    XCTAssertEqualObjects(expectedOrderOfKeys, orderedKeys);
+}
+
+- (void)testfailsWithGroupingOnNonGroupableView
+{
+    XCTestExpectation *completionFailed = [self expectationWithDescription:@"Grouping on view"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.group = YES;
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [completionFailed fulfill];
+      XCTAssertNotNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testCorrectlyQueryViewInculdingDocs
+{
+    XCTestExpectation *requestCompleted =
+        [self expectationWithDescription:@"Succesfully view query"];
+    XCTestExpectation *viewRowBlockCalled = [self expectationWithDescription:@"Document Found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.includeDocs = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlockCalled fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+      // Make sure the doc field is present.
+      XCTAssertNotNil(doc[@"doc"]);
+
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(10, numberOfDocs);
+}
+
+- (void)testCorrectlyQueryViewSkipDocs
+{
+    XCTestExpectation *requestCompleted =
+        [self expectationWithDescription:@"Succesfully view query"];
+    XCTestExpectation *viewRowBlockCalled = [self expectationWithDescription:@"Document Found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.skip = 9;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlockCalled fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(1, numberOfDocs);
+}
+
+- (void)testCorrectlyPages
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.limit = 5;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    __block NSString *lastDocId;
+    __block NSString *lastKey;
+
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+
+      lastDocId = (NSString *)doc[@"id"];
+      lastKey = (NSString *)doc[@"key"];
+
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(5, numberOfDocs);
+
+    XCTestExpectation *secondPageRequest =
+        [self expectationWithDescription:@"second page query sucuess"];
+    XCTestExpectation *foundDocuments =
+        [self expectationWithDescription:@"second page of documents"];
+
+    op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+
+    op.startKey = lastKey;
+    op.startKeyDocId = lastDocId;
+
+    // reset block variables
+    numberOfDocs = 0;
+    firstDoc = YES;
+
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [foundDocuments fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [secondPageRequest fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    // expect 6 since we will see one doc twice.
+    XCTAssertEqual(6, numberOfDocs);
+}
+
+- (void)testAbleToLimtDocsByStartKeyAndEndKey
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.startKey = @"carnivore";
+    op.startKeyDocId = @"panda";
+    op.endKey = @"herbivore";
+    op.endkeyDocId = @"giraffe";
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(2, numberOfDocs);
+}
+
+- (void)testAbleToLimtDocsByStartKeyAndEndKeyInclusiveEnd
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.startKey = @"carnivore";
+    op.startKeyDocId = @"panda";
+    op.endKey = @"herbivore";
+    op.endkeyDocId = @"giraffe";
+    op.inclusiveEnd = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(3, numberOfDocs);
+}
+
+- (void)testSuccessfulViewQueryReduce
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet_count";
+    op.reduce = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(1, numberOfDocs);
+}
+
+- (void)testSuccessfulViewQueryNoRowHandler
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet_count";
+    op.reduce = YES;
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testAbleToLimtDocsByStartKeyAndEndKeyInclusiveEndComplex
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"complex_count";
+    op.startKey = @[ @"bird", @"omnivore" ];
+    op.startKeyDocId = @"snipe";
+    op.endKey = @[ @"mammal", @"herbivore" ];
+    op.endkeyDocId = @"giraffe";
+    op.inclusiveEnd = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(4, numberOfDocs);
+}
+
+- (void)testFailureStartKeyIsInvalid
+{
+    XCTestExpectation *completionFailed =
+        [self expectationWithDescription:@"Keys and Key property set"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.startKey = @{};
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [completionFailed fulfill];
+      XCTAssertNotNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testFailureEndKeyIsInvalid
+{
+    XCTestExpectation *completionFailed =
+        [self expectationWithDescription:@"Keys and Key property set"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.endKey = @{};
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [completionFailed fulfill];
+      XCTAssertNotNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testFailureKeyIsInvalid
+{
+    XCTestExpectation *completionFailed =
+        [self expectationWithDescription:@"Keys and Key property set"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.key = @{};
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [completionFailed fulfill];
+      XCTAssertNotNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testFailureKeysIsInvalid
+{
+    XCTestExpectation *completionFailed =
+        [self expectationWithDescription:@"Keys and Key property set"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.keys = @{};
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [completionFailed fulfill];
+      XCTAssertNotNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+}
+
+- (void)testSuccessfulQueryViewWithKeyAsString
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.key = @"carnivore";
+    op.inclusiveEnd = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(2, numberOfDocs);
+}
+
+- (void)testSuccessfulQueryViewWithKeyAsArray
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"complex_count";
+    op.key = @[ @"bird", @"omnivore" ];
+    op.inclusiveEnd = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(1, numberOfDocs);
+}
+
+- (void)testSuccessfulQueryViewWithKeysAsString
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"diet";
+    op.keys = @[ @"carnivore", @"omnivore" ];
+    op.inclusiveEnd = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(6, numberOfDocs);
+}
+
+- (void)testSuccessfulQueryViewWithKeysAsArray
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"complex_count";
+    op.keys = @[ @[ @"bird", @"omnivore" ], @[ @"mammal", @"omnivore" ] ];
+    op.inclusiveEnd = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"id"]);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(4, numberOfDocs);
+}
+
+- (void)testSuccessfulQueryViewWithGrouping
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"complex_count";
+    op.group = YES;
+    op.reduce = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(5, numberOfDocs);
+}
+
+- (void)testSuccessfulQueryViewWithGroupLevel
+{
+    XCTestExpectation *requestCompleted = [self expectationWithDescription:@"Succesfully query db"];
+    XCTestExpectation *viewRowBlock = [self expectationWithDescription:@"Document found"];
+
+    CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
+    op.ddoc = @"views101";
+    op.viewName = @"complex_latin_name_count";
+    op.group = YES;
+    op.groupLevel = 2;
+    op.reduce = YES;
+
+    __block int numberOfDocs = 0;
+    __block BOOL firstDoc = YES;
+    op.viewRowBlock = ^(NSDictionary<NSString *, NSObject *> *doc) {
+      if (firstDoc) {
+          firstDoc = NO;
+          [viewRowBlock fulfill];
+      }
+      numberOfDocs++;
+      XCTAssertNotNil(doc);
+      XCTAssertNotNil(doc[@"key"]);
+      XCTAssertNotNil(doc[@"value"]);
+    };
+
+    op.queryViewCompletionBlock = ^(NSError *error) {
+      [requestCompleted fulfill];
+      XCTAssertNil(error);
+    };
+
+    [self.database addOperation:op];
+
+    [self waitForExpectationsWithTimeout:10.0f
+                                 handler:^(NSError *_Nullable error) {
+                                   NSLog(@"Operation completion handler not called");
+                                 }];
+
+    XCTAssertEqual(4, numberOfDocs);
+}
+
+@end

--- a/ObjectiveCloudantTests/QueryViewTests.m
+++ b/ObjectiveCloudantTests/QueryViewTests.m
@@ -103,7 +103,6 @@
 
     CDTQueryViewOperation *op = [[CDTQueryViewOperation alloc] init];
     op.ddoc = @"views101";
-    op.viewName = @"diet";
 
     op.queryViewCompletionBlock = ^(NSError *error) {
       [completionFailed fulfill];
@@ -230,6 +229,7 @@
       XCTAssertNotNil(doc[@"id"]);
       XCTAssertNotNil(doc[@"key"]);
       XCTAssertNotNil(doc[@"value"]);
+      XCTAssertNil(doc[@"doc"]);
 
       [orderedKeys addObject:doc[@"key"]];
     };
@@ -386,6 +386,7 @@
       XCTAssertNotNil(doc[@"id"]);
       XCTAssertNotNil(doc[@"key"]);
       XCTAssertNotNil(doc[@"value"]);
+      XCTAssertNil(doc[@"doc"]);
 
       lastDocId = (NSString *)doc[@"id"];
       lastKey = (NSString *)doc[@"key"];


### PR DESCRIPTION
## What

Add support for querying views using objective-cloudant.
## How

Follow the pattern used by CDTQueryFindDocumentsOperation which uses a two block processing model for the end user the interact with, so CDTQueryViewOperation has a block for processing view rows and one for marking the completion of the request.
## Reviewers

reviewer @brynh 
reviewer @mikerhodes
## Issues

Fixes #32
